### PR TITLE
Fixed skipped line return in src/languages/fr.lua

### DIFF
--- a/src/languages/fr.lua
+++ b/src/languages/fr.lua
@@ -19,7 +19,7 @@ s:set("output.success_single", "reussite")
 
 s:set("output.seconds", "secondes")
 
-s:set("assertion.same.positive", "Objets supposes de meme nature attendus. Argument passe:\n%s\Attendu:\n%s")
+s:set("assertion.same.positive", "Objets supposes de meme nature attendus. Argument passe:\n%s\nAttendu:\n%s")
 s:set("assertion.same.negative", "Objets supposes de natures differentes attendus. Argument passe:\n%s\nNon attendu:\n%s")
 
 s:set("assertion.equals.positive", "Objets supposes etre de valeur egale attendus. Argument passe:\n%s\nAttendu:\n%s")


### PR DESCRIPTION
I broke a  line return in src/languages/fr.lua. Fixed. 
Though, it's different from @ajacksified's [commit](https://github.com/Olivine-Labs/busted/commit/a1f76f6cc853ae4a423d3671deda4ece2bedaaa5).
