### PR TITLE
Fix coroutine detection

### DIFF
--- a/src/core.lua
+++ b/src/core.lua
@@ -1,3 +1,10 @@
+-- return truthy if we're in a coroutine
+local function in_coroutine()
+  local current_routine, main = coroutine.running()
+  -- need check to the main variable for 5.2, it's nil for 5.1
+  return current_routine and (main == nil or main == false)
+end
+
 local busted = {
   root_context = { type = "describe", description = "global" },
   options = {},
@@ -82,7 +89,7 @@ local busted = {
       if context.teardown then
         context.teardown()
       end
-      if coroutine.running() then
+      if in_coroutine() then
         coroutine.yield(status)
       else
         return true, status


### PR DESCRIPTION
coroutine.running() has changed semantics between 5.1 and
5.2, and now returns a second boolean indicating whether the
running coroutine is the main one.

https://github.com/Olivine-Labs/busted/issues/12 contains more information about the problem caused by this.

This is just a suggestion of one way of one of fixing of course, but if nothing else it illustrates the logic that is needed somewhere in order to support both 5.1 and 5.2.
