### PR TITLE
Correct the status check for test runs

### DIFF
--- a/src/core.lua
+++ b/src/core.lua
@@ -26,7 +26,7 @@ local busted = {
 
       local test_status = {}
 
-      if err then
+      if not status then
         test_status = { type = "failure", description = description, info = info, trace = stack_trace, err = err }
       else
         test_status = { type = "success", description = description, info = info }


### PR DESCRIPTION
We need to check status from xpcall, not err. Checking err means that any truthy return from an `it` will mark the spec as failed.

As an aside, you might very well wonder about the return from an `it`. Well if you, like me, write your specs in moonscript then the implicit returns means that will very often be a return value even from an `it`.
