### PR TITLE
Don't write \08 at the start of currently_executing in terminal outputters 

### DIFF
--- a/src/output/plain_terminal.lua
+++ b/src/output/plain_terminal.lua
@@ -118,10 +118,12 @@ local output = function()
     pending = pending_string,
   }
 
+  local on_first
   return {
     options = {},
 
     header = function(context_tree)
+      on_first = true
     end,
 
     footer = function(context_tree)
@@ -133,7 +135,13 @@ local output = function()
     end,
 
     currently_executing = function(test_status, options)
-      io.write("\08"..strings[test_status.type](options)..running_string(options))
+      if on_first then
+        on_first = false
+      else
+        io.write("\08")
+      end
+
+      io.write(strings[test_status.type](options)..running_string(options))
       io.flush()
     end
   }

--- a/src/output/utf_terminal.lua
+++ b/src/output/utf_terminal.lua
@@ -120,10 +120,12 @@ local output = function()
     pending = pending_string,
   }
 
+  local on_first
   return {
     options = {},
 
     header = function(context_tree)
+      on_first = true
     end,
 
     footer = function(context_tree)
@@ -135,7 +137,13 @@ local output = function()
     end,
 
     currently_executing = function(test_status, options)
-      io.write("\08"..strings[test_status.type](options)..running_string(options))
+      if on_first then
+        on_first = false
+      else
+        io.write("\08")
+      end
+
+      io.write(strings[test_status.type](options)..running_string(options))
       io.flush()
     end
   }


### PR DESCRIPTION
On my terminal it backspaces onto the previous line, giving me output like
this: (notice the first dot is on the same line as the command)

![dots](http://leafo.net/shotsnb/2012-09-07_23-17-02.png)
