### PR TITLE
added a path option to set the Lua module path

### DIFF
--- a/bin/busted_bootstrap
+++ b/bin/busted_bootstrap
@@ -79,6 +79,8 @@ if args then
   root_file = path..root_file
 
   if #args.lpath > 0 then
+    lpathprefix = lpathprefix:gsub("^%.[/%\\]", path )
+    lpathprefix = lpathprefix:gsub(";%.[/%\\]", ";" .. path)
     package.path = (lpathprefix .. ";" .. package.path):gsub(";;",";")
   end
 


### PR DESCRIPTION
It will now by default add the <code>./src</code> path to the Lua module path (after starting Buested, before loading the tests)

so when working on the cliargs.lua module, starting busted will load busted from the standard lua module path, but when the tests start it will load the code to be tested from the <code>src</code> folder.
