### PR TITLE
Added support for LuaCov to do coverage analysis

### DIFF
--- a/bin/busted_bootstrap
+++ b/bin/busted_bootstrap
@@ -71,10 +71,17 @@ if args then
   local path = args.d
 
   if args.coverage then
-    local result, luacov = pcall(require, "luacov")
+    local result, luacov = pcall(require, "luacov.runner")
     if not result then
       return print("LuaCov not found on the system, try running without --coverage option, or install LuaCov first")
     end
+    -- call it to start
+    luacov()
+    -- exclude busted files
+    table.insert(luacov.configuration.exclude, "busted_bootstrap$")
+    table.insert(luacov.configuration.exclude, "busted%.")
+    table.insert(luacov.configuration.exclude, "luassert%.")
+    table.insert(luacov.configuration.exclude, "say%.")
   end
 
   if (root_file:sub(1,1) == pathseparator) and (path:sub(-1,-1) == pathseparator) then


### PR DESCRIPTION
LuaCov update has just been released. This branch adds the <code>--coverage</code> commandline option.

Use LuaCovs <code>.coverage</code> configfile to configure how it runs.
