### PR TITLE
Fix the TAP output for;

### DIFF
--- a/src/core.lua
+++ b/src/core.lua
@@ -19,13 +19,6 @@ local root_context = { type = "describe", description = "global", before_each_st
 local current_context = root_context
 
 
--- return truthy if we're in a coroutine
-local function in_coroutine()
-  local current_routine, main = coroutine.running()
-  -- need check to the main variable for 5.2, it's nil for 5.1
-  return current_routine and (main == nil or main == false)
-end
-
 -- report a test-process error as a failed test
 local function internal_error(description, err)
   local tag = ""
@@ -231,24 +224,6 @@ local function run_context(context)
   
   return status
 end
-
---[[ Run set of test cases
-local function get_statuses(done, list)
-  local ret = {}
-  for _,v in ipairs(list) do
-    local vtype = type(v)
-    if vtype == "thread" then
-      local res = get_statuses(coroutine.resume(v))
-      for _,value in pairs(res) do
-        table.insert(ret, value)
-      end
-    elseif vtype == "table" then
-      table.insert(ret, v)
-    end
-  end
-  return ret
-end  ]]
-
 
 -- test runner
 busted.run = function(got_options)

--- a/src/output/TAP.lua
+++ b/src/output/TAP.lua
@@ -3,6 +3,8 @@
 --  output.descriptive_status
 --  output.currently_executing
 
+local s = require 'say'
+
 local output = function()
   local success_string = function(test_index, test_status)
     return string.format("ok %d - %s", test_index, test_status.description)
@@ -10,6 +12,14 @@ local output = function()
 
   local failure_string = function(test_index, test_status)
     return string.format("not ok %d - %s", test_index, test_status.description)
+  end
+  
+  local error_description = function(status, options)
+    return "\n\n"..s('output.failure')..": "..
+           status.info.short_src.." @ "..
+           status.info.linedefined..
+           "\n"..status.description..
+           "\n"..status.err
   end
 
   local pending_string = function(test_index, test_status, options)
@@ -57,17 +67,17 @@ local output = function()
         failures = inner_failures + failures
         pendings = inner_pendings + pendings
       elseif status.type == "success" then
+        short_status = short_status..success_string(index, status).."\n"
         index = index + 1
-        short_status = short_status..success_string(index, status)
         successes = successes + 1
       elseif status.type == "failure" then
+        short_status = short_status..failure_string(index, status).."\n"
+        descriptive_status = descriptive_status..error_description(status, options).."\n"
         index = index + 1
-        short_status = short_status..failure_string(index, status)
-        descriptive_status = descriptive_status..error_description(status, options)
         failures = failures + 1
       elseif status.type == "pending" then
+        short_status = short_status..pending_string(index, status, options).."\n"
         index = index + 1
-        short_status = short_status..pending_string(index, status, options)
         pendings = pendings + 1
       end
     end


### PR DESCRIPTION
Fix the TAP output for;
- displaying failures #87
- report 1st element instead of starting at 2nd with --defer-print option #94
- added newline for --defer-print option #94

Additionally removed some dead code from core.lua
