### PR TITLE
fix for bad after_each order

### DIFF
--- a/spec/core_spec.lua
+++ b/spec/core_spec.lua
@@ -237,13 +237,13 @@ local expected = [[setup A
     before_each A
       before_each B
         test B one
-      after_each A
-    after_each B
+      after_each B
+    after_each A
     before_each A
       before_each B
         test B two
-      after_each A
-    after_each B
+      after_each B
+    after_each A
   teardown B
   before_each A
     test A three

--- a/src/core.lua
+++ b/src/core.lua
@@ -363,7 +363,7 @@ busted.before_each = function(callback)
 end
 
 busted.after_each = function(callback)
-  table.insert(current_context.after_each_stack, callback)
+  table.insert(current_context.after_each_stack, 1, callback)
 end
 
 busted.setup = function(callback)


### PR DESCRIPTION
see this message: https://github.com/Olivine-Labs/busted/pull/98#issuecomment-13303038

Oh dear this is getting lengthy ... ;)

Concerning the core_spec.lua test "verifies order of execution": Running against the async branch failed. I think the execution order specified via string is wrong -> there is an error in the (olivine) master branch:

```
setup A
  before_each A
    test A one
  after_each A
  before_each A
    test A two
  after_each A
  setup B
    before_each A
      before_each B
        test B one
      after_each B
    after_each A
    before_each A
      before_each B
        test B two
      after_each B
    teardown B
  after_each A
  before_each A
    test A three
  after_each A
teardown A

Expected:
(string) setup A
  before_each A
    test A one
  after_each A
  before_each A
    test A two
  after_each A
  setup B
    before_each A
      before_each B
        test B one
      after_each A -- this is wrong. after_each B should be executed first.
    after_each B
    before_each A
      before_each B
        test B two
      after_each A
    after_each B
  teardown B
  before_each A
    test A three
  after_each A
teardown A
```
