### PR TITLE
bug fix; when no spec files

### DIFF
--- a/src/core.lua
+++ b/src/core.lua
@@ -78,7 +78,7 @@ local function gettestfiles(root_file, pattern)
       end )
   else
     filelist = {}
-    internal_error("Getting test files","No test files found for path '"..root_file.."' and pattern `"..pattern.."`. Please review your commandline.")
+    internal_error("Getting test files","No test files found for path '"..root_file.."' and pattern `"..pattern.."`. Please review your commandline, re-run with `--help` for usage.")
   end
   return filelist
 end


### PR DESCRIPTION
when running "busted" in a folder with no spec files (nor via defaults) it returns an error. This fixes it with a descriptive error message.
