### PR TITLE
Async support 2

### DIFF
--- a/spec/copas_spec.lua
+++ b/spec/copas_spec.lua
@@ -1,0 +1,45 @@
+local generic_async = require'generic_async_test'
+local statuses = busted.run_internal_test(function()
+    local copas = require'copas'
+    local socket = require'socket'
+    
+    local port = 19281
+    
+    local echo = function(done)
+      local listener = socket.bind('*',port)
+      copas.addthread(
+        guard(
+          function()
+            local s = socket.tcp()
+            s:setoption('tcp-nodelay',true)
+            copas.connect(s,'localhost',port)
+            local client = copas.wrap(s)
+            local msg = 'HALLO'
+            client:send(msg..'\n')
+            assert(client:receive('*l')==msg)
+            s:close()
+            listener:close()
+            done()
+        end))
+      copas.addserver(
+        listener,
+        guard(
+          function(skt)
+            while true do
+              local data = copas.receive(skt)
+              if not data then
+                return
+              end
+              copas.send(skt,data..'\n')
+            end
+        end))
+    end
+    
+    local yield = echo
+    
+    setloop('copas')
+    generic_async.setup_tests(yield,'copas')
+  end)
+
+generic_async.describe_statuses(statuses)
+

--- a/spec/ev_spec.lua
+++ b/spec/ev_spec.lua
@@ -1,0 +1,19 @@
+-- Runs internally an ev async test and checks the returned statuses.
+--
+--
+local generic_async = require'generic_async_test'
+local statuses = busted.run_internal_test(function()
+    local ev = require'ev'
+    local loop = ev.Loop.default
+    
+    local eps = 0.000000000001
+    local yield = function(done)
+      ev.Timer.new(
+        function()
+          done()
+        end,eps):start(loop)
+    end
+    setloop('ev')
+    generic_async.setup_tests(yield,'ev')
+  end)
+generic_async.describe_statuses(statuses)

--- a/spec/execution_order_ev_spec.lua
+++ b/spec/execution_order_ev_spec.lua
@@ -1,0 +1,76 @@
+local ev = require'ev'
+local loop = ev.Loop.default
+
+local eps = 0.000000000001
+
+local egg = ''
+local concat = function(letter)
+  local yield = function(done)
+    ev.Timer.new(
+      function()
+        egg = egg..letter
+        done()
+      end,eps):start(loop)
+  end
+  return yield
+end
+
+setloop('ev')
+
+describe(
+  'before_each after_each egg test',
+  function()
+    before(
+      async,
+    concat('S'))
+    
+    after(
+      async,
+    concat('T'))
+    
+    before_each(
+      async,
+    concat('b'))
+    
+    after_each(
+      async,
+    concat('a'))
+    
+    describe(
+      'asd',
+      function()
+        before_each(
+          async,
+        concat('B'))
+        
+        after_each(
+          async,
+        concat('A'))
+        
+        it(
+          '1',
+          function()
+            assert.equal(egg,'SbB')
+            egg = egg..'1'
+          end)
+        it(
+          '2',
+          function()
+            assert.equal(egg,'SbB1AabB')
+            egg = egg..'2'
+          end)
+      end)
+    it(
+      '3',
+      function()
+        assert.equal(egg,'SbB1AabB2Aab')
+        egg = egg..'3'
+      end)
+  end)
+
+it(
+  '4',
+  function()
+    assert.equal(egg,'SbB1AabB2Aab3aT')
+  end)
+

--- a/spec/execution_order_sync_spec.lua
+++ b/spec/execution_order_sync_spec.lua
@@ -1,0 +1,57 @@
+local egg = ''
+describe(
+  'before_each after_each egg test',
+  function()
+    before(
+      function()
+        egg = egg..'S'
+      end)
+    after(
+      function()
+        egg = egg..'T'
+      end)
+    before_each(
+      function()
+        egg = egg..'b'
+      end)
+    after_each(
+      function()
+        egg = egg..'a'
+      end)
+    describe(
+      'asd',
+      function()
+        before_each(
+          function()
+            egg = egg..'B'
+          end)
+        after_each(
+          function()
+            egg = egg..'A'
+          end)
+        it(
+          '1',
+          function()
+            assert.equal(egg,'SbB')
+            egg = egg..'1'
+          end)
+        it(
+          '2',
+          function()
+            assert.equal(egg,'SbB1AabB')
+            egg = egg..'2'
+          end)
+      end)
+    it(
+      '3',
+      function()
+        assert.equal(egg,'SbB1AabB2Aab')
+        egg = egg..'3'
+      end)
+  end)
+
+it(
+  '4',
+  function()
+    assert.equal(egg,'SbB1AabB2Aab3aT')
+  end)

--- a/src/core.lua
+++ b/src/core.lua
@@ -1,8 +1,9 @@
 local path = require('pl.path')
 local dir = require('pl.dir')
 local tablex = require('pl.tablex')
+require'pl'
 
-local busted = {}   -- exported module table
+busted = {}-- exported module table
 busted._COPYRIGHT   = "Copyright (c) 2013 Olivine Labs, LLC."
 busted._DESCRIPTION = "A unit testing framework with a focus on being easy to use. http://www.olivinelabs.com/busted"
 busted._VERSION     = "Busted 1.7"
@@ -13,29 +14,25 @@ busted.defaultpattern = '_spec.lua$'
 busted.defaultlua = 'luajit'
 busted.lpathprefix = "./src/?.lua;./src/?/?.lua;./src/?/init.lua"
 busted.cpathprefix = path.is_windows and "./csrc/?.dll;./csrc/?/?.dll;" or "./csrc/?.so;./csrc/?/?.so;"
-require('busted.languages.en')    -- Load default language pack
+require('busted.languages.en')-- Load default language pack
 
-local failures = 0
-local options
-local root_context = { type = "describe", description = "global", before_each_stack = {}, after_each_stack = {} }
-local current_context = root_context
-
+local options = {}
 
 -- report a test-process error as a failed test
-local function internal_error(description, err)
+local internal_error = function(description, err)
   local tag = ""
   if options.tags and #options.tags > 0 then
     -- tags specified; must insert a tag to make sure the error gets displayed
     tag = " #"..options.tags[1]
   end
   describe("Busted process errors occured" .. tag, function()
-    it(description .. tag, function()
-      error(err)
+      it(description .. tag, function()
+          error(err)
+        end)
     end)
-  end)
 end
 
-local function language(lang)
+local language = function(lang)
   if lang then
     busted.messages = require('busted.languages.'..lang)
     require('luassert.languages.'..lang)
@@ -43,18 +40,22 @@ local function language(lang)
 end
 
 -- load the outputter as set in the options, revert to default if it fails
-local function getoutputter(output, opath, default)
+local getoutputter = function(output, opath, default)
   local success, out, f
   if output:match(".lua$") then
-    f = function() return loadfile(path.normpath(path.join(opath, output)))() end
+    f = function()
+      return loadfile(path.normpath(path.join(opath, output)))()
+    end
   else
-    f = function() return require('busted.output.'..output)() end
+    f = function()
+      return require('busted.output.'..output)()
+    end
   end
-
+  
   success, out = pcall(f)
   if not success then
     if not default then
-        -- even default failed, so error out the hard way
+      -- even default failed, so error out the hard way
       return error("Failed to open the busted default output; " .. tostring(output) .. ".\n"..out)
     else
       internal_error("Unable to open output module; requested option '--output=" .. tostring(output).."'.", out)
@@ -66,7 +67,7 @@ local function getoutputter(output, opath, default)
 end
 
 -- acquire set of test files from the options specified
-local function gettestfiles(root_file, pattern)
+local gettestfiles = function(root_file, pattern)
   local filelist
   if path.isfile(root_file) then
     filelist = { root_file }
@@ -84,7 +85,7 @@ local function gettestfiles(root_file, pattern)
 end
 
 -- runs a testfile, loading its tests
-local function load_testfile(filename)
+local load_testfile = function(filename)
   local old_TEST = _TEST
   _TEST = busted._VERSION
   
@@ -92,15 +93,15 @@ local function load_testfile(filename)
   if not success then
     internal_error("Failed executing testfile; " .. tostring(filename), err)
   end
-
+  
   _TEST = old_TEST
 end
 
 local play_sound = function(failures)
   math.randomseed(os.time())
-
+  
   if busted.messages.failure_messages and #busted.messages.failure_messages > 0 and
-     busted.messages.success_messages and #busted.messages.success_messages > 0 then
+  busted.messages.success_messages and #busted.messages.success_messages > 0 then
     if failures and failures > 0 then
       io.popen("say \""..busted.messages.failure_messages[math.random(1, #busted.messages.failure_messages)]:format(failures).."\"")
     else
@@ -114,272 +115,467 @@ end
 -- Test engine
 --=============================
 
---run a single test
-local function test(description, callback, no_output)
-  local debug_info = debug.getinfo(callback)
+local push = table.insert
 
-  local info = {
-    source = debug_info.source,
-    short_src = debug_info.short_src,
-    linedefined = debug_info.linedefined,
-  }
+local suite = {
+  tests = {},
+  done = {},
+  started = {},
+  test_index = 1,
+  loop_pcall = pcall,
+  loop_step = function() end,
+}
 
-  local stack_trace = ""
+local options
 
-  local function err_handler(err)
-    stack_trace = debug.traceback("", 4)
-    return err
+step = function(...)
+  local steps = {...}
+  if #steps == 1 and type(steps[1]) == 'table' then
+    steps = steps[1]
   end
-
-  local status, err = xpcall(callback, err_handler)
-
-  local test_status = {}
-
-  if not status then
-    if type(err) == "table" then
-      err = pretty.write(err)
+  local i = 0
+  local next
+  next = function()
+    i = i + 1
+    local step = steps[i]
+    if step then
+      step(next)
     end
-
-    test_status = { type = "failure", description = description, info = info, trace = stack_trace, err = err }
-    failures = failures + 1
-  else
-    test_status = { type = "success", description = description, info = info }
   end
-
-  if not no_output and not options.defer_print then
-    busted.output.currently_executing(test_status, options)
-  end
-
-  return test_status
+  next()
 end
 
--- run setup/teardown
-local function run_setup(context, stype, decsription)
-  if not context[stype] then
-    return true
-  else
-    if type(context[stype]) == "function" then
-      local result = test("Failed running test initializer '"..stype.."'", context[stype], true)
-      return (result.type == "success"), result
-    elseif type(context[stype]) == "table" then
-      if #context[stype] > 0 then
-        local result
+busted.step = step
 
-        for _,v in ipairs(context[stype]) do
-          result = test("Failed running test initializer '"..decsription.."'", v, true)
+guard = function(f,test)
+  local test = suite.tests[suite.test_index]
+  local safef = function(...)
+    local result = {suite.loop_pcall(f,...)}
+    if result[1] then
+      return unpack(result,2)
+    else
+      local err = result[2]
+      if type(err) == "table" then
+        err = pretty.write(err)
+      end
+      test.status.type = 'failure'
+      test.status.trace = debug.traceback("", 2)
+      test.status.err = err
+      assert(type(test.done) == 'function','non-test step failed (before/after/etc.):\n'..err)
+      test.done()
+    end
+  end
+  return safef
+end
 
-          if result.type ~= "success" then
-            return (result.type == "success"), result
+busted.guard = guard
+
+local next_test
+next_test = function()
+  if #suite.done == #suite.tests then
+    return
+  end
+  if not suite.started[suite.test_index] then
+    suite.started[suite.test_index] = true
+    local test = suite.tests[suite.test_index]
+    assert(test,suite.test_index..debug.traceback('',1))
+    local steps = {}
+    local execute_test = function(next)
+      local done = function()
+        if test.done_trace then
+          if test.status.err == nil then
+            test.status.err = 'test already "done":"'..test.name..'"'
+            test.status.err = test.status.err..'. First called from '..test.done_trace
+            test.status.type = 'failure'
+            test.status.trace = debug.traceback("", 2)
+          end
+          return
+        end
+        assert(suite.test_index <= #suite.tests,'invalid test index: '..suite.test_index)
+        suite.done[suite.test_index] = true
+        -- keep done trace for easier error location when called multiple time
+        test.done_trace = pretty.write(debug.traceback("", 2))
+        if not options.defer_print then
+          busted.output.currently_executing(test.status, options)
+        end
+        test.context:decrement_test_count()
+        next()
+      end
+      test.done = done
+      local ok,err = suite.loop_pcall(test.f,done)
+      if not ok then
+        if type(err) == "table" then
+          err = pretty.write(err)
+        end
+        test.status.type = 'failure'
+        test.status.trace = debug.traceback("", 2)
+        test.status.err = err
+        done()
+      end
+    end
+    
+    local check_before = function(context)
+      if context.before then
+        local execute_before = function(next)
+          context.before(
+            function()
+              context.before = nil
+              next()
+            end)
+        end
+        push(steps,execute_before)
+      end
+    end
+    
+    local parents = test.context.parents
+    
+    for p=1,#parents do
+      check_before(parents[p])
+    end
+    
+    check_before(test.context)
+    
+    for p=1,#parents do
+      if parents[p].before_each then
+        push(steps,parents[p].before_each)
+      end
+    end
+    
+    if test.context.before_each then
+      push(steps,test.context.before_each)
+    end
+    
+    push(steps,execute_test)
+    
+    if test.context.after_each then
+      push(steps,test.context.after_each)
+    end
+    
+    local post_test = function(next)
+      local post_steps = {}
+      local check_after = function(context)
+        if context.after then
+          if context:all_tests_done() then
+            local execute_after = function(next)
+              context.after(
+                function()
+                  context.after = nil
+                  next()
+                end)
+            end
+            push(post_steps,execute_after)
           end
         end
-
-        return (result.type == "success"), result
-      else
-        return true
       end
+      
+      for p=#parents,1,-1 do
+        if parents[p].after_each then
+          push(post_steps,parents[p].after_each)
+        end
+      end
+      
+      check_after(test.context)
+      
+      for p=#parents,1,-1 do
+        check_after(parents[p])
+      end
+      
+      local forward = function(next)
+        suite.test_index = suite.test_index + 1
+        next_test()
+        next()
+      end
+      push(post_steps,forward)
+      step(post_steps)
+    end
+    push(steps,post_test)
+    step(steps)
+  end
+end
+
+local create_context = function(desc)
+  local context = {
+    desc = desc,
+    parents = {},
+    test_count = 0,
+    increment_test_count = function(self)
+      self.test_count = self.test_count + 1
+      for _,parent in ipairs(self.parents) do
+        parent.test_count = parent.test_count + 1
+      end
+    end,
+    decrement_test_count = function(self)
+      self.test_count = self.test_count - 1
+      for _,parent in ipairs(self.parents) do
+        parent.test_count = parent.test_count - 1
+      end
+    end,
+    all_tests_done = function(self)
+      return self.test_count == 0
+    end,
+    add_parent = function(self,parent)
+      push(self.parents,parent)
+    end
+  }
+  return context
+end
+
+local suite_name
+local current_context
+busted.describe = function(desc,more)
+  if not suite_name then
+    suite_name = desc
+  end
+  local context = create_context(desc)
+  for i,parent in ipairs(current_context.parents) do
+    context:add_parent(parent)
+  end
+  context:add_parent(current_context)
+  local old_context = current_context
+  current_context = context
+  more()
+  current_context = old_context
+end
+
+busted.before = function(sync_before,async_before)
+  if async_before then
+    current_context.before = async_before
+  else
+    current_context.before = function(done)
+      sync_before()
+      done()
     end
   end
 end
 
---run single test case
-local function run_context(context)
-  local match = false
+busted.before_each = function(sync_before,async_before)
+  if async_before then
+    current_context.before_each = async_before
+  else
+    current_context.before_each = function(done)
+      sync_before()
+      done()
+    end
+  end
+end
 
-  if options.tags and #options.tags > 0 then
-    for _,t in ipairs(options.tags) do
-      if context.description:find("#"..t) then
-        match = true
+busted.after = function(sync_after,async_after)
+  if async_after then
+    current_context.after = async_after
+  else
+    current_context.after = function(done)
+      sync_after()
+      done()
+    end
+  end
+end
+
+busted.after_each = function(sync_after,async_after)
+  if async_after then
+    current_context.after_each = async_after
+  else
+    current_context.after_each = function(done)
+      sync_after()
+      done()
+    end
+  end
+end
+
+busted.pending = function(name)
+  local test = {}
+  test.context = current_context
+  test.context:increment_test_count()
+  test.name = name
+  local debug_info = debug.getinfo(2)
+  test.f = function(done)
+    done()
+  end
+  test.status = {
+    description = name,
+    type = 'pending',
+    info = {
+      source = debug_info.source,
+      short_src = debug_info.short_src,
+      linedefined = debug_info.linedefined,
+    }
+  }
+  suite.tests[#suite.tests+1] = test
+end
+
+busted.it = function(name,sync_test,async_test)
+  local test = {}
+  test.context = current_context
+  test.context:increment_test_count()
+  test.name = name
+  
+  local debug_info
+  if async_test then
+    debug_info = debug.getinfo(async_test)
+    test.f = async_test
+  else
+    debug_info = debug.getinfo(sync_test)
+    -- make sync test run async
+    test.f = function(done)
+      sync_test()
+      done()
+    end
+  end
+  test.status = {
+    description = test.name,
+    type = 'success',
+    info = {
+      source = debug_info.source,
+      short_src = debug_info.short_src,
+      linedefined = debug_info.linedefined,
+    }
+  }
+  suite.tests[#suite.tests+1] = test
+end
+
+busted.reset = function()
+  current_context = create_context('Root context')
+  suite = {
+    tests = {},
+    done = {},
+    started = {},
+    test_index = 1,
+    loop_pcall = pcall,
+    loop_step = function() end,
+  }
+  suite_name = nil
+end
+
+busted.setloop = function(...)
+  local args = {...}
+  if type(args[1]) == 'string' then
+    local loop = args[1]
+    if loop == 'ev' then
+      local ev = require'ev'
+      suite.loop_pcall = pcall
+      suite.loop_step = function()
+        ev.Loop.default:loop()
+      end
+    elseif loop == 'copas' then
+      local copas = require'copas'
+      require'coxpcall'
+      suite.loop_pcall = copcall
+      suite.loop_step = function()
+        copas.step(0)
       end
     end
   else
-    match = true
+    suite.loop_step = args[1]
+    suite.loop_pcall = args[2] or pcall
   end
+end
 
-  local status = { description = context.description, type = "description", run = match }
-  local setup_ok, setup_error
-
-  setup_ok, setup_error = run_setup(context, "setup")
-
-  if setup_ok then
-    for _,v in ipairs(context) do
-      if v.type == "test" then
-        setup_ok, setup_error = run_setup(context, "before_each_stack", "before_each")
-        if not setup_ok then break end
-
-        table.insert(status, test(v.description, v.callback))
-
-        setup_ok, setup_error = run_setup(context, "after_each_stack", "after_each")
-        if not setup_ok then break end
-      elseif v.type == "describe" then
-        local res = run_context(v)
-        for key,value in ipairs(res) do
-          table.insert(status, value)
-        end
-      elseif v.type == "pending" then
-        local pending_test_status = { type = "pending", description = v.description, info = v.info }
-        v.callback(pending_test_status)
-        table.insert(status, pending_test_status)
-      end
-    end
-  end
-
-  if setup_ok then setup_ok, setup_error = run_setup(context, "teardown") end
-
-  if not setup_ok then table.insert(status, setup_error) end
+busted.run_internal_test = function(describe_tests)
+  local suite_bak = suite
+  local output_bak = busted.output
+  busted.output = {currently_executing=function() end}
+  suite = {
+    tests = {},
+    done = {},
+    started = {},
+    test_index = 1
+  }
+  describe_tests()
+  repeat
+    next_test()
+    suite.loop_step()
+  until #suite.done == #suite.tests
   
-  return status
+  local statuses = {}
+  for _,test in ipairs(suite.tests) do
+    push(statuses,test.status)
+  end
+  suite = suite_bak
+  busted.output = output_bak
+  return statuses
 end
 
 -- test runner
 busted.run = function(got_options)
-
   options = got_options
-  failures = 0
-
+  
   language(options.lang)
   busted.output = getoutputter(options.output, options.fpath, busted.defaultoutput)
   -- if no filelist given, get them
   options.filelist = options.filelist or gettestfiles(options.root_file, options.pattern)
   -- load testfiles
-  tablex.foreachi(options.filelist, load_testfile)
-
+  
   local ms = os.clock()
-
-  if not options.defer_print then
-    print(busted.output.header(root_context))
+  
+  local statuses = {}
+  local failures = 0
+  local suites = {}
+  local tests = 0
+  
+  for i,filename in ipairs(options.filelist) do
+    local old_TEST = _TEST
+    _TEST = busted._VERSION
+    
+    busted.reset()
+    
+    suite._TEST = _TEST
+    
+    load_testfile(filename)
+    tests = tests + #suite.tests
+    
+    suites[i] = suite
+    _TEST = old_TEST
   end
-
-  local old_TEST = _TEST
-  _TEST = busted._VERSION
-  local statuses = run_context(root_context)
-
+  
+  if not options.defer_print then
+    print(busted.output.header('global',tests))
+  end
+  
+  for i,filename in ipairs(options.filelist) do
+    
+    _TEST = suites[i]._TEST
+    suite = suites[i]
+    
+    repeat
+      next_test()
+      suite.loop_step()
+    until #suite.done == #suite.tests
+    
+    for _,test in ipairs(suite.tests) do
+      push(statuses,test.status)
+      if test.status.type == 'failure' then
+        failures = failures + 1
+      end
+    end
+  end
+  
   --final run time
   ms = os.clock() - ms
-
-  if options.defer_print then
-    print(busted.output.header(root_context))
-  end
-
+  
   local status_string = busted.output.formatted_status(statuses, options, ms)
-
+  
   if options.sound then
     play_sound(failures)
   end
-
-  if not options.defer_print then
-    print(busted.output.footer(root_context))
-  end
-
-  _TEST = old_TEST
+  
   return status_string, failures
 end
 
-
---=============================
--- Global test functions
---=============================
-busted.describe = function(description, callback)
-  local match = current_context.run
-  local parent = current_context
-
-  if options.tags and #options.tags > 0 then
-    for _,t in ipairs(options.tags) do
-      if description:find("#"..t) then
-        match = true
-      end
-    end
-  else
-    match = true
-  end
-
-  local local_context = {
-    description = description,
-    callback = callback,
-    type = "describe",
-    run = match,
-    before_each_stack = {},
-    after_each_stack = {}
-  }
-
-  for _,v in pairs(current_context.before_each_stack) do
-    table.insert(local_context.before_each_stack, v)
-  end
-
-  for _,v in pairs(current_context.after_each_stack) do
-    table.insert(local_context.after_each_stack, v)
-  end
-
-  table.insert(current_context, local_context)
-
-  current_context = local_context
-
-  callback()
-
-  current_context = parent
-end
-
-busted.it = function(description, callback)
-  assert(current_context ~= root_context, debug.traceback("An it() block must be wrapped in a describe() block/n", 2))
-  local match = current_context.run
-
-  if not match then
-    if options.tags and #options.tags > 0 then
-      for _,t in ipairs(options.tags) do
-        if description:find("#"..t) then
-          match = true
-        end
-      end
-    end
-  end
-
-  if match then
-    table.insert(current_context, { description = description, callback = callback, type = "test" })
-  end
-end
-
-busted.pending = function(description, callback)
-  assert(current_context ~= root_context, debug.traceback("A pending() block must be wrapped in a describe() block/n", 2))
-  local debug_info = debug.getinfo(callback)
-
-  local info = {
-    source = debug_info.source,
-    short_src = debug_info.short_src,
-    linedefined = debug_info.linedefined,
-  }
-
-  local test_status = {
-    description = description,
-    type = "pending",
-    info = info,
-    callback = function(self)
-      if not options.defer_print then
-        busted.output.currently_executing(self, options)
-      end
-    end
-  }
-
-  table.insert(current_context, test_status)
-end
-
-busted.before_each = function(callback)
-  table.insert(current_context.before_each_stack, callback)
-end
-
-busted.after_each = function(callback)
-  table.insert(current_context.after_each_stack, 1, callback)
-end
-
-busted.setup = function(callback)
-  current_context.setup = callback
-end
-
-busted.teardown = function(callback)
-  current_context.teardown = callback
-end
-
+it = busted.it
+pending = busted.pending
+describe = busted.describe
+before = busted.before
+after = busted.after
+setup = busted.before
+busted.setup = busted.before
+teardown = busted.after
+busted.teardown = busted.after
+before_each = busted.before_each
+after_each = busted.after_each
+step = step
+setloop = busted.setloop
 
 return setmetatable(busted, {
     __call = function(self, ...)
       return busted.run(...)
-    end } )
+  end } )
 

--- a/src/generic_async_test.lua
+++ b/src/generic_async_test.lua
@@ -1,0 +1,228 @@
+local setup_async_tests = function(yield,loopname)
+  describe(
+    loopname..' test suite',
+    function()
+      local before_each_count = 0
+      local before_called
+      before(
+        async,
+        function(done)
+          yield(guard(
+              function()
+                before_called = true
+                done()
+            end))
+          
+        end)
+      
+      before_each(
+        async,
+        function(done)
+          yield(guard(
+              function()
+                before_each_count = before_each_count + 1
+                done()
+            end))
+        end)
+      
+      it(
+        'should async succeed',
+        async,
+        function(done)
+          yield(guard(
+              function()
+                assert.is_true(before_called)
+                assert.is.equal(before_each_count,1)
+                done()
+            end))
+        end)
+      
+      it(
+        'should async fail',
+        async,
+        function(done)
+          yield(guard(
+              function()
+                assert.is_truthy(false)
+                done()
+            end))
+        end)
+      
+      it(
+        'should async fails epicly',
+        async,
+        function(done)
+          does_not_exist.foo = 3
+        end)
+      
+      it(
+        'should succeed',
+        async,
+        function(done)
+          done()
+        end)
+      
+      it(
+        'spies should sync succeed',
+        function()
+          assert.is.equal(before_each_count,5)
+          local thing = {
+            greet = function()
+            end
+          }
+          spy.on(thing, "greet")
+          thing.greet("Hi!")
+          assert.spy(thing.greet).was.called()
+          assert.spy(thing.greet).was.called_with("Hi!")
+        end)
+      
+      it(
+        'spies should async succeed',
+        async,
+        function(done)
+          local thing = {
+            greet = function()
+            end
+          }
+          spy.on(thing, "greet")
+          yield(guard(
+              function()
+                assert.spy(thing.greet).was.called()
+                assert.spy(thing.greet).was.called_with("Hi!")
+                done()
+            end))
+          thing.greet("Hi!")
+        end)
+      
+      describe(
+        'with nested contexts',
+        function()
+          local before_called
+          before(
+            async,
+            function(done)
+              yield(guard(
+                  function()
+                    before_called = true
+                    done()
+                end))
+            end)
+          it(
+            'nested async test before is called succeeds',
+            async,
+            function(done)
+              yield(guard(
+                  function()
+                    assert.is_true(before_called)
+                    done()
+                end))
+            end)
+        end)
+      
+      pending('is pending')
+      
+      it(
+        'calling done twice fails',
+        async,
+        function(done)
+          yield(guard(
+              function()
+                done()
+                done()
+            end))
+        end)
+      
+    end)
+end
+
+local describe_statuses = function(statuses,print_statuses)
+  if print_statuses then
+    print('---------- STATUSES ----------')
+    print(pretty.write(statuses))
+    print('------------------------------')
+  end
+  
+  describe(
+    'Test statuses',
+    function()
+      it(
+        'type is correct',
+        function()
+          for i,status in ipairs(statuses) do
+            local type = status.type
+            assert.is_truthy(type == 'failure' or type == 'success' or type == 'pending')
+            local succeed = status.description:match('succeed')
+            local fail = status.description:match('fail')
+            local pend = status.description:match('pend')
+            local count = 0
+            if succeed then
+              count = count + 1
+            end
+            if fail then
+              count = count + 1
+            end
+            if pend then
+              count = count + 1
+            end
+            assert.equal(count,1)
+            if succeed then
+              assert(status.type == 'success', status.description)
+            elseif fail then
+              assert(status.type == 'failure', status.description)
+            elseif pend then
+              assert(status.type == 'pending', status.description)
+            end
+          end
+        end)
+      
+      it(
+        'info is correct',
+        function()
+          for i,status in ipairs(statuses) do
+            assert.is_truthy(status.info.linedefined)
+            assert.is_truthy(status.info.source:match('generic_async_test%.lua'))
+            assert.is_truthy(status.info.short_src:match('generic_async_test%.lua'))
+          end
+        end)
+      
+      it(
+        'provides "err" for failed tests',
+        function()
+          for i,status in ipairs(statuses) do
+            if status.type == 'failure' then
+              assert.is.equal(type(status.err),'string')
+              assert.is_not.equal(#status.err,0)
+            end
+          end
+        end)
+      
+      it(
+        'provides "traceback" for failed tests',
+        function()
+          for i,status in ipairs(statuses) do
+            if status.type == 'failure' then
+              assert.is.equal(type(status.trace),'string')
+              assert.is_not.equal(#status.trace,0)
+            end
+          end
+        end)
+      
+      it(
+        'calling done twice fails is reported correctly',
+        function()
+          for i,status in ipairs(statuses) do
+            if status.description:match('.*done.*twice') then
+              assert.is_truthy(status.err:match('.*First called from.*stack traceback'))
+              return
+            end
+          end
+          assert.is_falsy('twice report failed')
+        end)
+      
+    end)
+end
+
+return {
+   setup_tests = setup_async_tests,
+   describe_statuses = describe_statuses
+       }

--- a/src/output/TAP.lua
+++ b/src/output/TAP.lua
@@ -86,12 +86,9 @@ local output = function()
   end
 
   return {
-    header = function(context_tree)
-      io.write("1.."..test_length(context_tree))
+    header = function(desc, test_count)
+      io.write("1.."..test_count)
       io.flush()
-    end,
-
-    footer = function(context_tree)
     end,
 
     formatted_status = function(statuses, options, ms)

--- a/src/output/json.lua
+++ b/src/output/json.lua
@@ -7,11 +7,9 @@ local json = require("dkjson")
 
 local output = function()
   return {
-    header = function(context_tree)
+    header = function(desc, test_count)
     end,
 
-    footer = function(context_tree)
-    end,
 
     formatted_status = function(statuses, options, ms)
       if options.defer_print then

--- a/src/output/junit.lua
+++ b/src/output/junit.lua
@@ -5,19 +5,17 @@ local hostname = assert ( io.popen ( "uname -n" ) ):read ( "*l" )
 return function ()
 	local node
 	return {
-		header = function(context_tree)
+		header = function(desc, test_count)
 			node = xml.new("testsuite",{
 				errors    = 0 ;
 				failures  = 0 ;
 				hostname  = hostname ;
-				name      = context_tree.description ;
+				name      = desc ;
 				tests     = 0 ;
 				--time      = ;
 				timestamp = os.time ( ) ;
 				skip      = 0 ;
 			})
-		end ;
-		footer = function(context_tree)
 		end ;
 		formatted_status = function(statuses, options, ms)
 			node.attr.time = ms

--- a/src/output/plain_terminal.lua
+++ b/src/output/plain_terminal.lua
@@ -122,12 +122,10 @@ local output = function()
   return {
     options = {},
 
-    header = function(context_tree)
+    header = function(desc, test_count)
       on_first = true
     end,
 
-    footer = function(context_tree)
-    end,
 
     formatted_status = function(statuses, options, ms)
       local short_status, descriptive_status, successes, failures, pendings = format_statuses(statuses, options)

--- a/src/output/utf_terminal.lua
+++ b/src/output/utf_terminal.lua
@@ -124,12 +124,10 @@ local output = function()
   return {
     options = {},
 
-    header = function(context_tree)
+    header = function(desc, test_count)
       on_first = true
     end,
 
-    footer = function(context_tree)
-    end,
 
     formatted_status = function(statuses, options, ms)
       local short_status, descriptive_status, successes, failures, pendings = format_statuses(statuses, options)


### PR DESCRIPTION
# Changes
## Allow async tests

Specifying `before_each`,`after_each`,`setup`,`teardown` and `it` to run async:

``` lua
local ev = require'ev'
local timer = function(on_timeout)
  ev.Timer.new(function()
      on_timeout()
    end,0.01):start(ev.Loop.default)
end

-- specify the loop framework ('copas' or 'ev')
setloop('ev')

describe('Some async stuff',function()
    before(
      async,-- Specify "async" as first arg / replacement for the busted callback.
      function(done)-- The following arg is the async busted callback.
        timer(-- Setup an async before action.
          function()
            done()-- The async callback must call "done" to proceed
          end
        )
      end)

    it('make some async test',async,function(done)
        timer(-- Sets up an async callback
          guard(-- The callback must be wrapped in "guard",
            -- to allow busted to keep track of all errors etc
            function()
              assert.is_true(true)-- Use any assertion library
              done()-- Call "done" to proceed with the next test step.
              -- This might be calling "after_each",
              -- "before_each","it" .. depending on your suite.
            end)
        )
      end)
  end)

```

At the moment lua-ev and copas are supported. 
## More tests

Checkout https://github.com/lipp/busted/blob/async-test-support/spec/execution_order_ev_spec.lua and other newly added specs.
# Implementation Notes
- run loop reimplementation
- Interface to output modules' `header` and `footer` method have changes
- based on this PR: https://github.com/Olivine-Labs/busted/pull/98
