### PR TITLE
Moonscript support for busted

### DIFF
--- a/src/moon.lua
+++ b/src/moon.lua
@@ -1,0 +1,76 @@
+local success, ms = pcall(function() return require("moonscript") end)
+if not success then
+  return {
+    is_moon=function(x) return false end,
+    loadfile=loadfile
+  }
+end
+
+local util = require("moonscript.util")
+local line_tables = require("moonscript.line_tables")
+local table = require("table")
+
+local _cache = {}
+
+local is_moon = function(fname)
+  return fname:find(".moon", #fname-6, true) and true or false
+end
+
+local loader = function(fname)  
+  if is_moon(fname) then
+    return ms.loadfile(fname)
+  else
+    return loadfile(fname)
+  end
+end
+
+-- find the line number of `pos` chars into fname
+local lookup_line = function(fname, pos)
+  if not _cache[fname] then
+    local f = io.open(fname)
+    _cache[fname] = f:read("*a")
+    f:close()
+  end
+  return util.pos_to_line(_cache[fname], pos)
+end
+
+local rewrite_linenumber = function(fname, lineno)
+  local tbl = line_tables[fname]  
+  if fname and tbl then    
+    for i = lineno,0,-1 do
+      if tbl[i] then
+        return lookup_line(fname, tbl[i])
+      end
+    end
+  end
+end
+
+local rewrite_traceback = function(err, trace)
+  local lines = {}
+  local j = 0
+
+  local rewrite_one = function(line)
+    local fname, lineno = line:match('[^"]+"([^:]+)".:(%d+):')
+    if fname and lineno then      
+      local new_lineno = rewrite_linenumber(fname, tonumber(lineno))
+      if new_lineno then
+        line = line:gsub(':' .. lineno .. ':', ':' .. new_lineno .. ':')
+      end
+    end
+    return line
+  end
+
+  for line in trace:gmatch("[^\r\n]+") do
+    j = j + 1    
+    lines[j] = rewrite_one(line)
+  end
+
+  return rewrite_one(err), table.concat(lines, trace:match("[\r\n]+"))
+end
+
+return {
+    loadfile=loader,
+    is_moon=is_moon,
+    rewrite_linenumber=rewrite_linenumber,
+    rewrite_traceback=rewrite_traceback
+}


### PR DESCRIPTION
You can now run moon tests with: 

busted test_example.moon 

Line numbers and tracebacks will automatically be changed to match the moonscript line numbers, if possible.
