### PR TITLE
Fix moonscript error rewriting

### DIFF
--- a/src/core.lua
+++ b/src/core.lua
@@ -255,7 +255,7 @@ next_test = function()
           err = pretty.write(err)
         end
 
-        trace = debug.traceback("", 2)
+        local trace = debug.traceback("", 2)
         err, trace = moon.rewrite_traceback(err, trace)
 
         test.status.type = 'failure'


### PR DESCRIPTION
It was still broken in the (main?) place tracebacks were created.

Should work now. Is there any easy way to add tests for the error rewriting so know if it breaks in future? Just a simple moon test with an error 'foo' in it, and verify that the line numbers are different from the compiled lua, and that they are rewritten to match the moonscript line numbers in the test.status.err and test.status.trace.
