### PR TITLE
Use lua socket if available to time tests

### DIFF
--- a/src/core.lua
+++ b/src/core.lua
@@ -36,6 +36,20 @@ local internal_error = function(description, err)
   end)
 end
 
+-- returns current time in seconds
+local function get_time()
+  local success, socket = pcall(function() return require "socket" end)
+  if success then
+    get_time = function()
+      return socket.gettime()
+    end
+  else
+    get_time = os.clock
+  end
+
+  return get_time()
+end
+
 local language = function(lang)
   if lang then
     busted.messages = require('busted.languages.'..lang)
@@ -606,7 +620,7 @@ busted.run = function(got_options)
   options.filelist = options.filelist or gettestfiles(options.root_file, options.pattern)
   -- load testfiles
 
-  local ms = os.clock()
+  local ms = get_time()
 
   local statuses = {}
   local failures = 0
@@ -650,7 +664,7 @@ busted.run = function(got_options)
   end
 
   --final run time
-  ms = os.clock() - ms
+  ms = get_time() - ms
 
   local status_string = busted.output.formatted_status(statuses, options, ms)
 

--- a/src/output/plain_terminal.lua
+++ b/src/output/plain_terminal.lua
@@ -65,11 +65,13 @@ local output = function()
       short_status = ""
     end
 
+    local formatted_time = ("%.6f"):format(ms):gsub("([0-9])0+$", "%1")
+
     return short_status.."\n"..
            successes.." "..success_str..", "..
            failures.." "..failure_str..", and "..
            pendings.." "..pending_str.." in "..
-           ms.." "..s('output.seconds').."."..descriptive_status
+           formatted_time.." "..s('output.seconds').."."..descriptive_status
   end
 
   format_statuses = function (statuses, options)

--- a/src/output/utf_terminal.lua
+++ b/src/output/utf_terminal.lua
@@ -66,12 +66,13 @@ local output = function()
       short_status = ""
     end
 
+    local formatted_time = ("%.6f"):format(ms):gsub("([0-9])0+$", "%1")
 
     return short_status.."\n"..
     ansicolors('%{green}'..successes).." "..success_str.." / "..
     ansicolors('%{red}'..failures).." "..failure_str.." / "..
     ansicolors('%{yellow}'..pendings).." "..pending_str.." : "..
-    ansicolors('%{bright}'..ms).." "..s('output.seconds').."."..descriptive_status
+    ansicolors('%{bright}'..formatted_time).." "..s('output.seconds').."."..descriptive_status
   end
 
   format_statuses = function (statuses, options)


### PR DESCRIPTION
This uses `socket.gettime` to time the tests if lua socket is installed. `os.clock` isn't very good because it (at least on my computer) doesn't have very good precision. Also, it keeps track of CPU time and not actual time elapsed, so it can be very wrong if your tests sleep.
