### PR TITLE
change default pattern; remove .lua

### DIFF
--- a/src/core.lua
+++ b/src/core.lua
@@ -12,7 +12,7 @@ busted._VERSION     = "Busted 1.7"
 
 -- set defaults
 busted.defaultoutput = path.is_windows and "plain_terminal" or "utf_terminal"
-busted.defaultpattern = '_spec.lua$'
+busted.defaultpattern = '_spec'
 busted.defaultlua = 'luajit'
 busted.lpathprefix = "./src/?.lua;./src/?/?.lua;./src/?/init.lua"
 busted.cpathprefix = path.is_windows and "./csrc/?.dll;./csrc/?/?.dll;" or "./csrc/?.so;./csrc/?/?.so;"


### PR DESCRIPTION
Since we support moonscript now, perhaps we should drop .lua from the default pattern.

We might also consider changing from lua patterns to regex or lpeg, so we could do things like `_spec.(moon|lua)` to make this safer. Interested in comments.
