### PR TITLE
remove async flag for async tests. Now auto-detects sync/async.

### DIFF
--- a/spec/copas_spec.lua
+++ b/spec/copas_spec.lua
@@ -14,7 +14,7 @@ else
       local listener = socket.bind('*',port)
 
       copas.addthread(
-        guard(
+        async(
           function()
             local s = socket.tcp()
 
@@ -36,7 +36,7 @@ else
 
       copas.addserver(
         listener,
-        guard(
+        async(
           function(skt)
             while true do
               local data = copas.receive(skt)

--- a/spec/execution_order_ev_spec.lua
+++ b/spec/execution_order_ev_spec.lua
@@ -14,7 +14,7 @@ else
   local concat = function(letter)
     local yield = function(done)
       ev.Timer.new(
-        guard(function()
+        async(function()
           egg = egg..letter
           done()
         end),eps):start(loop)

--- a/src/core.lua
+++ b/src/core.lua
@@ -199,7 +199,7 @@ local suite = {
 
 local options
 
-step = function(...)
+busted.step = function(...)
   local steps = { ... }
   if #steps == 1 and type(steps[1]) == 'table' then
     steps = steps[1]
@@ -220,10 +220,12 @@ step = function(...)
   next()
 end
 
-busted.step = step
-
-guard = function(f, test)
+busted.async = function(f, test)
   test_is_async = true
+  if not f then
+    -- this allows async() to be called on its own to mark any test as async.
+    return
+  end
   local test = suite.tests[suite.test_index]
 
   local safef = function(...)
@@ -251,8 +253,6 @@ guard = function(f, test)
   return safef
 end
 
-busted.guard = guard
-
 local match_tags = function(testName)
   if #options.tags > 0 then
 
@@ -274,7 +274,7 @@ local syncwrapper = function(f)
     test_is_async = nil
     f(done, ...)
     if not test_is_async then
-      -- guard function wasn't called, so it is a sync test/function
+      -- async function wasn't called, so it is a sync test/function
       -- hence must call it ourselves
       done()
     end
@@ -724,19 +724,20 @@ busted.run = function(got_options)
   return status_string, failures
 end
 
-it = busted.it
-pending = busted.pending
-describe = busted.describe
-before = busted.before
-after = busted.after
-setup = busted.before
-busted.setup = busted.before
-teardown = busted.after
+busted.setup    = busted.before
 busted.teardown = busted.after
-before_each = busted.before_each
-after_each = busted.after_each
-step = step
-setloop = busted.setloop
+it              = busted.it
+pending         = busted.pending
+describe        = busted.describe
+before          = busted.before
+after           = busted.after
+setup           = busted.setup
+teardown        = busted.teardown
+before_each     = busted.before_each
+after_each      = busted.after_each
+step            = busted.step
+setloop         = busted.setloop
+async           = busted.async
 
 return setmetatable(busted, {
   __call = function(self, ...)

--- a/src/generic_async_test.lua
+++ b/src/generic_async_test.lua
@@ -6,7 +6,7 @@ local setup_async_tests = function(yield,loopname)
       local before_called
       before(
         function(done)
-          yield(guard(
+          yield(async(
               function()
                 before_called = true
                 done()
@@ -16,7 +16,7 @@ local setup_async_tests = function(yield,loopname)
       
       before_each(
         function(done)
-          yield(guard(
+          yield(async(
               function()
                 before_each_count = before_each_count + 1
                 done()
@@ -26,7 +26,7 @@ local setup_async_tests = function(yield,loopname)
       it(
         'should async succeed',
         function(done)
-          yield(guard(
+          yield(async(
               function()
                 assert.is_true(before_called)
                 assert.is.equal(before_each_count,1)
@@ -37,7 +37,7 @@ local setup_async_tests = function(yield,loopname)
       it(
         'should async fail',
         function(done)
-          yield(guard(
+          yield(async(
               function()
                 assert.is_truthy(false)
                 done()
@@ -78,7 +78,7 @@ local setup_async_tests = function(yield,loopname)
             end
           }
           spy.on(thing, "greet")
-          yield(guard(
+          yield(async(
               function()
                 assert.spy(thing.greet).was.called()
                 assert.spy(thing.greet).was.called_with("Hi!")
@@ -93,7 +93,7 @@ local setup_async_tests = function(yield,loopname)
           local before_called
           before(
             function(done)
-              yield(guard(
+              yield(async(
                   function()
                     before_called = true
                     done()
@@ -102,7 +102,7 @@ local setup_async_tests = function(yield,loopname)
           it(
             'nested async test before is called succeeds',
             function(done)
-              yield(guard(
+              yield(async(
                   function()
                     assert.is_true(before_called)
                     done()
@@ -115,7 +115,7 @@ local setup_async_tests = function(yield,loopname)
       it(
         'calling done twice fails',
         function(done)
-          yield(guard(
+          yield(async(
               function()
                 done()
                 done()


### PR DESCRIPTION
instead of writing

``` lua
  it("does some async test", async, function(done)
    -- some test stuff
  end
```

it now allows for the same syntax as sync (except for the `done` parameter)

``` lua
  it("does some async test", function(done)
    -- some test stuff
  end
```

Auto detection is based on the assumption that every async test should at least post 1 callback wrapped in `guard()`. Correct?

So if, after the `it()` callback returns, `guard()` hasn't been called, then `done()` still needs to be called explicitly for a sync test.

Also applies to the `before_each`, `after_each`, `setup` and `teardown`.

@lipp what do you think?
