### PR TITLE
add ev token tests

### DIFF
--- a/spec/ev_spec.lua
+++ b/spec/ev_spec.lua
@@ -19,10 +19,14 @@ else
           done()
         end,eps):start(loop)
     end
-      
+
+    local create_timer = function(timeout,done)
+       ev.Timer.new(done,timeout):start(loop)
+    end
+    
     setloop('ev')
       
-    generic_async.setup_tests(yield,'ev')
+    generic_async.setup_tests(yield,'ev',create_timer)
   end)
   
   generic_async.describe_statuses(statuses)


### PR DESCRIPTION
actually the token tests only require a create_timer method and can be applied generically to all async loops.
