### PR TITLE
Make tests to look a bit better

### DIFF
--- a/spec/core_spec.lua
+++ b/spec/core_spec.lua
@@ -11,7 +11,7 @@ local test_val = false
 
 assert.is_not_nil(_TEST)  -- test on file-level
 
-describe("testing global _TEST", function()
+describe "testing global _TEST" (function()
   
   assert.is_not_nil(_TEST)
   
@@ -31,51 +31,51 @@ describe("testing global _TEST", function()
     assert.is_not_nil(_TEST)
   end)
 
-  it("Tests the _TEST global in an it() block", function()
+  it "Tests the _TEST global in an it() block" (function()
     assert.is_not_nil(_TEST)
   end)
 
 end)
 
-describe("Test Case", function()
+describe "Test Case" (function()
   local test_val = true
   assert(test_val)
 end)
 
-describe("Test case", function()
+describe "Test case" (function()
   local test_val = false
-  it("changes test_val to true", function()
+  it "changes test_val to true" (function()
     test_val = true
     assert(test_val)
   end)
 end)
 
-describe("Before each", function()
+describe "Before each" (function()
   local test_val = false
 
   before_each(function()
     test_val = true
   end)
 
-  it("is called", function()
+  it "is called" (function()
     assert(test_val)
   end)
 end)
 
-describe("After each", function()
+describe "After each" (function()
   local test_val = false
 
   after_each(function()
     test_val = true
   end)
 
-  it("runs once to fire an after_each and then", function() end)
-  it("checks if after_each was called", function()
+  it "runs once to fire an after_each and then" (function() end)
+  it "checks if after_each was called" (function()
    assert(test_val)
   end)
 end)
 
-describe("Both before and after each", function()
+describe "Both before and after each" (function()
   local test_val = 0
 
   before_each(function()
@@ -86,78 +86,78 @@ describe("Both before and after each", function()
     test_val = test_val + 1
   end)
 
-  it("checks if both were called", function() end)
-  it("runs again just to be sure", function() end)
+  it "checks if both were called" (function() end)
+  it "runs again just to be sure" (function() end)
 
-  it("checks the value", function() 
+  it "checks the value" (function() 
     assert(test_val == 5)
   end)
 end)
 
-describe("Before_each on describe blocks", function()
+describe "Before_each on describe blocks" (function()
   local test_val = 0
 
   before_each(function()
     test_val = test_val + 1
   end)
 
-  describe("A block", function()
-    it("derps", function()
+  describe "A block" (function()
+    it "derps" (function()
       assert(test_val == 1)
     end)
 
-    it("herps", function()
+    it "herps" (function()
       assert(test_val == 2)
     end)
   end)
 end)
 
-describe("Before_each on describe blocks, part II", function()
+describe "Before_each on describe blocks, part II" (function()
   local test_val = 0
 
   before_each(function()
     test_val = test_val + 1
   end)
 
-  it("checks the value", function()
+  it "checks the value" (function()
     assert.are.equal(1, test_val)
   end)
 
-  describe("A block", function()
+  describe "A block" (function()
     before_each(function()
       test_val = test_val + 1
     end)
 
-    it("derps", function() end) --add two: two before-eaches
-    it("herps", function() end)
+    it "derps" (function() end) --add two: two before-eaches
+    it "herps" (function() end)
 
-    it("checks the value", function()
+    it "checks the value" (function()
       assert(test_val == 7)
     end)
   end)
 end)
 
-describe("A failing test", function()
-  it("explodes", function()
+describe "A failing test" (function()
+  it "explodes" (function()
     assert.has.error(function() assert(false, "this should fail") end)
   end)
 end)
 
-describe("tagged tests #test", function()
-  it("runs", function()
+describe "tagged tests #test" (function()
+  it "runs" (function()
     assert(true)
   end)
 end)
 
 
-describe("Testing test order", function()
+describe "Testing test order" (function()
   
   local testorder, level = "", 0
   local function report_level(desc)
     testorder = testorder .. string.rep(" ", level * 2) .. desc .. "\n"
   end
 
-  describe("describe, level A", function()
+  describe "describe, level A" (function()
   
     setup(function()
       report_level("setup A")
@@ -179,15 +179,15 @@ describe("Testing test order", function()
       report_level("after_each A")
     end)
 
-    it("tests A one", function()
+    it "tests A one" (function()
       report_level("test A one")        
     end)
     
-    it("tests A two", function()
+    it "tests A two" (function()
       report_level("test A two")        
     end)
 
-    describe("describe level B", function()
+    describe "describe level B" (function()
 
       setup(function()
         report_level("setup B")
@@ -209,24 +209,24 @@ describe("Testing test order", function()
         report_level("after_each B")
       end)
 
-      it("tests B one", function()
+      it "tests B one" (function()
         report_level("test B one")
       end)
       
-      it("tests B two", function()
+      it "tests B two" (function()
         report_level("test B two")        
       end)
           
     end)
   
-    it("tests A three", function()
+    it "tests A three" (function()
       report_level("test A three")        
     end)
 
   end)
     
-  describe("Test testorder", function()
-    it("verifies order of execution", function()
+  describe "Test testorder" (function()
+    it "verifies order of execution" (function()
 local expected = [[setup A
   before_each A
     test A one
@@ -258,7 +258,7 @@ teardown A
 
 end)
 
-it("Malformated Lua code gets reported correctly", function()
+it "Malformated Lua code gets reported correctly" (function()
   local filename = ".malformed_test.lua"
   local f = io.open(filename,"w")
   f:write("end)") -- write some non-sense which will cause a parse error
@@ -272,10 +272,10 @@ it("Malformated Lua code gets reported correctly", function()
   os.remove(filename)
 end)
 
-it("finally callback is called in case of success", function()
+it "finally callback is called in case of success" (function()
   local f = spy.new(function() end)
   busted.run_internal_test(function()
-	  it("write variable in finally",function()
+	  it "write variable in finally" (function()
 		  finally(f)
 			assert.is_true(true)						     
 		end)
@@ -283,10 +283,10 @@ it("finally callback is called in case of success", function()
   assert.spy(f).was_called(1)
 end)
 
-it("finally callback is called in case of error", function()
+it "finally callback is called in case of error" (function()
   local f = spy.new(function() end)
   busted.run_internal_test(function()
-		it("write variable in finally",function()
+		it "write variable in finally" (function()
 			finally(f)
 			assert.is_true(false)						     
 		end)
@@ -295,9 +295,9 @@ it("finally callback is called in case of error", function()
 end)
 
 
-describe("testing the done callback with tokens", function()
+describe "testing the done callback with tokens" (function()
   
-  it("Tests done call back ordered", function(done)
+  it "Tests done call back ordered" (function(done)
     stub(done, "done_cb") -- create a stub to prevent actually calling 'done'
     done:wait_ordered("1", "2", "3")
     assert.has_no_error(function() done("1") end)
@@ -311,7 +311,7 @@ describe("testing the done callback with tokens", function()
     done.done_cb:revert() -- revert so test can complete
   end)
   
-  it("Tests done call back unordered", function(done)
+  it "Tests done call back unordered" (function(done)
     stub(done, "done_cb") -- create a stub to prevent actually calling 'done'
     done:wait_unordered("1", "2", "3")
     assert.has_no_error(function() done("1") end)
@@ -324,7 +324,7 @@ describe("testing the done callback with tokens", function()
     done.done_cb:revert() -- revert so test can complete
   end)
   
-  it("Tests done call back defaulting to ordered", function(done)
+  it "Tests done call back defaulting to ordered" (function(done)
     stub(done, "done_cb") -- create a stub to prevent actually calling 'done'
     done:wait("1", "2")
     assert.has_error(function() done("2") end)     -- different order
@@ -336,7 +336,7 @@ describe("testing the done callback with tokens", function()
 end)
 
 --[[  TODO: uncomment this failing test and fix it
-describe("testing done callbacks being provided", function()
+describe "testing done callbacks being provided" (function()
   setup(function(done)
     assert.is_table(done)
     assert.is_function(done.wait)
@@ -353,13 +353,13 @@ describe("testing done callbacks being provided", function()
     assert.is_table(done)
     assert.is_function(done.wait)
   end)
-  it("Tests done callbacks being provided", function(done)
+  it "Tests done callbacks being provided" (function(done)
     assert.is_table(done)
     assert.is_function(done.wait)
   end)
 end)
 
-describe("testing done callbacks being provided for async tests", function()
+describe "testing done callbacks being provided for async tests" (function()
   setup(function(done)
     async()
     assert.is_table(done)
@@ -380,7 +380,7 @@ describe("testing done callbacks being provided for async tests", function()
     assert.is_table(done)
     assert.is_function(done.wait)
   end)
-  it("Tests done callbacks being provided for async tests", function(done)
+  it "Tests done callbacks being provided for async tests" (function(done)
     async()
     assert.is_table(done)
     assert.is_function(done.wait)


### PR DESCRIPTION
This allows us to transform

describe("CONTEXT", function()
  it("DOES SOMETHING", function()
    -- do something
  end)
end)

into

describe "CONTEXT" (function()
  it "DOES SOMETHING" (function()
    -- do something
  end)
end)

which is easier to read (and write too, no comma :) )

Uses that Lua syntactic sugar:
  function("STR")  is equal to function "STR"
and a little bit of functional programming (anonymous funcs + closures)
