### PR TITLE
Fix an issue when busted is called with -o my/output.lua

### DIFF
--- a/src/core.lua
+++ b/src/core.lua
@@ -764,7 +764,7 @@ busted.run = function(got_options)
   options = got_options
 
   language(options.lang)
-  busted.output = getoutputter(options.output, options.fpath, busted.defaultoutput)
+  busted.output = getoutputter(options.output, options.path, busted.defaultoutput)
   busted.output_reset = busted.output  -- store in case we need a reset
   -- if no filelist given, get them
   options.filelist = options.filelist or gettestfiles(options.root_file, options.pattern)


### PR DESCRIPTION
- This change makes sure opath is not nil
- When trying busted -o my/output.lua, busted was failing with:

Busted process errors occured / Unable to open output module; requested option '--output=my/output.lua'.
$HOME/.luarocks/share/lua/5.1/busted/core.lua:67: $HOME/.luarocks/share/lua/5.1/pl/path.lua:233: argument 1 expected a 'string', got a 'nil'
