### PR TITLE
don't pass the lua interpreter argument to the lua interpreter

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -16,6 +16,8 @@ while getopts ":l:" optchar; do
   esac
 done
 
+shift $(($OPTIND - 1))
+
 if commandExists $COMMAND ; then
   COMMAND=$COMMAND;
 elif commandExists $LUA ; then


### PR DESCRIPTION
This is pretty self explanatory, but just in case.  If "-l /usr/bin/some-other-lua" is passed to busted, busted passes "-l /usr/bin/some-other-lua" to /usr/bin/some-other-lua.  This fixes that by remove it from the arguments.
