### PR TITLE
Do not abort on non-string errors

### DIFF
--- a/src/core.lua
+++ b/src/core.lua
@@ -257,6 +257,8 @@ busted.async = function(f)
       local err = result[2]
       if type(err) == "table" then
         err = pretty.write(err)
+      elseif type(err) ~= "string" then
+        err = tostring(err)
       end
 
       local stack_trace = debug.traceback("", 2)
@@ -423,6 +425,8 @@ next_test = function()
     else
       if type(err) == "table" then
         err = pretty.write(err)
+      elseif type(err) ~= "string" then
+        err = tostring(err)
       end
 
       -- remove all frames after the last frame found in the test file


### PR DESCRIPTION
Commit a62819e only addresses tables. Any other error not coerced to string, in
particular `nil`, can bust busted. The following test exposes the problem:

```
describe('busted', function ()
    it('must handle any error value', function () error() end)
end)
```

and results in:

```
[...]/utf_terminal.lua:22: attempt to concatenate field 'err' (a nil value)
```

This patch forcibly converts `err` to `tostring(err)` if it is not string or a
table onthe core side.
