### PR TITLE
Output handlers: Concatenate traceback only if it is not nil.

### DIFF
--- a/busted/outputHandlers/plainTerminal.lua
+++ b/busted/outputHandlers/plainTerminal.lua
@@ -44,7 +44,7 @@ return function(options, busted)
       end
     end
 
-    if options.verbose then
+    if options.verbose and failure.trace.traceback then
       string = string .. '\n' .. failure.trace.traceback
     end
 

--- a/busted/outputHandlers/utfTerminal.lua
+++ b/busted/outputHandlers/utfTerminal.lua
@@ -45,7 +45,7 @@ return function(options, busted)
       end
     end
 
-    if options.verbose then
+    if options.verbose and failure.trace.traceback then
       string = string .. '\n' .. failure.trace.traceback
     end
 


### PR DESCRIPTION
If there are errors with the tests, the traceback might be nil, which causes a string concatenation to fail if the `verbose` option is set:

```
./usr/share/lua/5.1/busted/outputHandlers/utfTerminal.lua:49: attempt to concatenate field 'traceback' (a nil value)
```

Checking if the traceback is nil before concatenation fixes that.
