### PR TITLE
Correctly use loaded config file

### DIFF
--- a/bin/busted
+++ b/bin/busted
@@ -71,6 +71,8 @@ if bustedConfigFile then
 
   if err then
     print(err)
+  else
+    cliArgs = config
   end
 end
 


### PR DESCRIPTION
The configuration file info is parsed and stored into <code>config</code> and then never used again (the rest of the loader uses <code>cliArgs</code>).  This means that using a config file has no effect.  Changed so that after the config is loaded successfully it's used as <code>cliArgs</code>.
