### PR TITLE
Fix error message for .lua test files with syntax errors

### DIFF
--- a/busted/modules/files/lua.lua
+++ b/busted/modules/files/lua.lua
@@ -16,20 +16,10 @@ end
 
 
 ret.load = function(busted, filename)
-  local file, err
-
-  local success, err = pcall(function()
-    file, err = loadfile(filename)
-
-    if not file then
-      busted.publish({ 'error', 'file' }, filename, nil, nil, err)
-    end
-  end)
-
-  if not success then
-    busted.publish({ 'error', 'file' }, filename, nil, nil, err)
+  local file, err = loadfile(filename)
+  if not file then
+    busted.publish({ 'error', 'file' }, filename, nil, err, {})
   end
-
   return file, getTrace
 end
 


### PR DESCRIPTION
When loadfile() fails for a .lua test file you were passing 'err' as the 'trace' object, and it was being ignored (busted printed only "Error", nothing else). Now I'm passing 'err' as the message, and an empty {} trace object just for compatibility with the output handlers... I considered passing { traceback = err } but err is not a traceback, so I think passing it as an error message makes more sense

I also removed an unnecessary pcall() and duplicate code.
