### PR TITLE
Fix issue #291 TAP output type is broken in 2.0rc3

### DIFF
--- a/busted/outputHandlers/TAP.lua
+++ b/busted/outputHandlers/TAP.lua
@@ -28,7 +28,7 @@ return function(options, busted)
 
     for i,t in pairs(handler.successes) do
       counter = counter + 1
-      print(counter .. ' ' .. handler.format(t).name)
+      print( success:format( counter, handler.format(t).name ))
     end
 
     for i,t in pairs(handler.failures) do
@@ -41,7 +41,7 @@ return function(options, busted)
         message = pretty.write(message)
       end
 
-      print(counter .. ' ' .. handler.format(t).name)
+      print( failure:format( counter, handler.format(t).name ))
       print('# ' .. t.trace.short_src .. ' @ ' .. t.trace.currentline)
       print('# Failure message: ' .. message:gsub('\n', '\n# ' ))
     end


### PR DESCRIPTION
The success and failure format strings were bypassed in commit 88f7850.

Now, if the following two tests are run with TAP output, we will get the
expected ok/not ok formats.

$ bin/busted -o TAP spec/cl_spec.lua
1..1
ok 1 - Tests the busted command-line options

$ bin/busted -o TAP spec/cl_two_failures.lua
1..2
not ok 1 - Runs 2 failing tests is failing test 2
(details omitted)
not ok 2 - Runs 2 failing tests is failing test 1
(details omitted)
