### PR TITLE
correct the order in the say assertion messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -576,8 +576,8 @@ local function has_property(state, arguments)
   return state.mod == has_key
 end
 
-s:set("assertion.has_property.positive", "Expected %s to have:\n%s")
-s:set("assertion.has_property.negative", "Expected %s to not have:\n%s")
+say:set("assertion.has_property.positive", "Expected %s \nto have property: %s")
+say:set("assertion.has_property.negative", "Expected %s \nto not have property: %s")
 assert:register("assertion", "has_property", has_property, "assertion.has_property.positive", "assertion.has_property.negative")
 
 describe("my table", function()


### PR DESCRIPTION
The message from the example yields:

```
./spec/my_spec.lua:12: Expected property (table): {
  [name] = 'masiak'
  [age] = 32 } in:
(string) 'last_name'
```

After my tweak, it now prints:

```
./spec/my_spec.lua:12: Expected (table): {
  [name] = 'masiak'
  [age] = 32 } 
to have property: (string) 'last_name'
```

This might be due to my environment, running LuaJIT? but I thought I'd just share the patch here.
