### PR TITLE
Change rockspec URL to git+https

### DIFF
--- a/.github/workflows/busted.yml
+++ b/.github/workflows/busted.yml
@@ -45,18 +45,18 @@ jobs:
           luarocks install copas
           luarocks install lua-ev
           luarocks install luacov
-          luarocks install --deps-only busted-scm-2.rockspec
+          luarocks install --deps-only busted-scm-1.rockspec
 
       - name: Build ‘busted’ (bootstrap)
         run: |
           luarocks make
 
       - name: Run ‘busted’ (dogfood)
-        # disable the paths to force use of installed rockspec
-        run: busted -c -v --lpath="" --cpath="" --Xoutput "--color"
+        # disable project-local path prefixes to force use of system installation
+        run: busted --coverage --lpath="" --cpath="" -Xoutput --color
 
       - name: Report test coverage
-        if: success()
+        if: ${{ success() && github.repository == 'lunarmodules/busted' }}
         continue-on-error: true
         run: luacov-coveralls -i src -e .luarocks
         env:

--- a/busted-scm-1.rockspec
+++ b/busted-scm-1.rockspec
@@ -1,6 +1,6 @@
 local package_name = "busted"
 local package_version = "scm"
-local rockspec_revision = "2"
+local rockspec_revision = "1"
 local github_account_name = "lunarmodules"
 local github_repo_name = package_name
 local git_checkout = package_version == "scm" and "master" or package_version

--- a/busted-scm-2.rockspec
+++ b/busted-scm-2.rockspec
@@ -1,7 +1,7 @@
 package = 'busted'
 version = 'scm-2'
 source = {
-  url = "git://github.com/Olivine-Labs/busted",
+  url = "git+https://github.com/Olivine-Labs/busted",
   branch = "master"
 }
 description = {


### PR DESCRIPTION
Resolves this error:

```
Cloning into 'busted'...
fatal: remote error:
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

Cf. <https://github.com/Olivine-Labs/busted/issues/668#issuecomment-1073215957>.