### PR TITLE
Setup repo for use *as* GH Action

### DIFF
--- a/.github/workflows/busted.yml
+++ b/.github/workflows/busted.yml
@@ -1,6 +1,19 @@
+# ATTENTION
+#
+# This is *not* a typical busted workflow! Do not copy this to other projects!
+# Instead of installing busted from somewhere and using it on a code base,
+# we're actually building and running the current HEAD version on ourselves:
+# basically this is a combination bootstrap test and dogfooding. The upshot is
+# that we check both that everything works (and end-to-end test) and that the
+# current codebase checks against itself. This ensures we can fix a bug or make
+# a breaking change in busted without being blocked by our own CI using a
+# different busted verision.
+#
+# See the README.md file for examples suitable for use in other projects.
+
 name: Busted
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
 
@@ -8,39 +21,42 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        luaVersion: ["5.4", "5.3", "5.2", "5.1", "luajit", "luajit-openresty"]
-        penlightVersion: ["1.9.2", "1.8.0", "1.6.0", "1.3.2"]
-    runs-on: ubuntu-20.04
+        luaVersion: [ "5.4", "5.3", "5.2", "5.1", "luajit" ] #, "luajit-openresty" ]
+        penlightVersion: [ "1.13.1", "1.9.2", "1.8.0", "1.6.0", "1.3.2" ]
+    runs-on: ubuntu-22.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Setup ‘lua’
-      uses: leafo/gh-actions-lua@v8
-      with:
-        luaVersion: ${{ matrix.luaVersion }}
-    - name: Setup ‘luarocks’
-      uses: leafo/gh-actions-luarocks@v4
-    - name: Setup dependencies
-      run: |
-        sudo apt-get install libev-dev
-        luarocks install penlight ${{ matrix.penlightVersion }}
-        luarocks install --only-deps busted-scm-2.rockspec
-        luarocks install luasec
-        luarocks install moonscript
-        luarocks install copas
-        luarocks install lua-ev
-        luarocks install luacov
-    - name: Cache Lua machinery
-      uses: actions/cache@v2
-      with:
-        path: |
-          .install
-          .lua
-          .luarocks
-        key: lua-${{ matrix.luaVersion }}-${{ matrix.penlightVersion }}-${{ hashFiles('busted-scm-2.rockspec', '.github/workflows/busted.yml') }}
-    - name: Build
-      run: |
-        luarocks remove busted --force ||:
-        luarocks make
-    - name: Run tests
-      run: busted -v
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup ‘lua’
+        uses: leafo/gh-actions-lua@v9
+        with:
+          luaVersion: ${{ matrix.luaVersion }}
+
+      - name: Setup ‘luarocks’
+        uses: leafo/gh-actions-luarocks@v4
+
+      - name: Setup dependencies
+        run: |
+          sudo apt-get install libev-dev
+          luarocks install penlight ${{ matrix.penlightVersion }}
+          luarocks install luasec
+          luarocks install moonscript
+          luarocks install copas
+          luarocks install lua-ev
+          luarocks install luacov
+          luarocks install --deps-only busted-scm-2.rockspec
+
+      - name: Build ‘busted’ (bootstrap)
+        run: |
+          luarocks make
+
+      - name: Run ‘busted’ (dogfood)
+        run: busted -c -v
+
+      - name: Report test coverage
+        if: success()
+        continue-on-error: true
+        run: luacov-coveralls -i src -e .luarocks
+        env:
+          COVERALLS_REPO_TOKEN: ${{ github.token }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy
+
+on: [ push, workflow_dispatch ]
+
+jobs:
+
+  affected:
+    uses: lunarmodules/.github/.github/workflows/list_affected_rockspecs.yml@main
+
+  build:
+    needs: affected
+    if: ${{ needs.affected.outputs.rockspecs }}
+    uses: lunarmodules/.github/.github/workflows/test_build_rock.yml@main
+    with:
+      rockspecs: ${{ needs.affected.outputs.rockspecs }}
+
+  upload:
+    needs: [ affected, build ]
+    # Only run upload if:
+    # 1. We are on the canonical repository (no uploads from forks)
+    # 2. The current commit is either tagged or on the default branch (the workflow will upload dev/scm rockspecs any
+    #    time they are touched, tagged ones whenever the edited rockspec and tag match)
+    # 3. Some rockspecs were changed — this implies the commit changing the rockspec is the same one that gets tagged
+    if: >-
+      ${{
+        github.repository == 'lunarmodules/busted' &&
+        ( github.ref_name == 'master' || startsWith(github.ref, 'refs/tags/') ) &&
+        needs.affected.outputs.rockspecs
+      }}
+    uses: lunarmodules/.github/.github/workflows/upload_to_luarocks.yml@main
+    with:
+      rockspecs: ${{ needs.affected.outputs.rockspecs }}
+    secrets:
+      apikey: ${{ secrets.LUAROCKS_APIKEY }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,3 +32,16 @@ jobs:
       rockspecs: ${{ needs.affected.outputs.rockspecs }}
     secrets:
       apikey: ${{ secrets.LUAROCKS_APIKEY }}
+
+  docker:
+    if: >-
+      ${{
+        github.repository == 'lunarmodules/busted' &&
+        ( github.ref_name == 'master' || startsWith(github.ref, 'refs/tags/') )
+      }}
+    uses: lunarmodules/.github/.github/workflows/docker_ghcr_deploy.yml@main
+    with:
+      username: ${{ github.actor }}
+      tag: ${{ github.ref_name }}
+    secrets:
+      token: ${{ secrets.GHCR_PAT }}

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,16 @@
+name: Versioning
+
+on:
+  release:
+    types: [ created, published, edited ]
+
+jobs:
+  actions-tagger:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Update release tags
+        uses: Actions-R-Us/actions-tagger@v2
+        with:
+          publish_latest_tag: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Here's some examples of things you might want to make a pull request for:
 
 If you have a more deeply-rooted problem with how the program is built or some
 of the stylistic decisions made in the code, it's best to
-[create an issue](https://github.com/Olivine-Labs/busted/issues) before putting
+[create an issue](https://github.com/lunarmodules/busted/issues) before putting
 the effort into a pull request. The same goes for new features - it is
 best to check the project's direction, existing pull requests, and currently open
 and closed issues first.
@@ -34,7 +34,7 @@ be found in the README.
 
 ## Using Git appropriately
 
-1. [Fork the repository](https://github.com/Olivine-Labs/busted/fork_select) to
+1. [Fork the repository](https://github.com/lunarmodules/busted/fork_select) to
   your Github account.
 2. Create a *topical branch* - a branch whose name is succint but explains what
   you're doing, such as "romanian-translation"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+#syntax=docker/dockerfile:1.2
+
+FROM akorn/luarocks:lua5.4-alpine AS builder
+
+RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+	dumb-init gcc libc-dev
+
+COPY ./ /src
+WORKDIR /src
+
+RUN luarocks --tree /pkgdir/usr/local make
+RUN find /pkgdir -type f -exec sed -i -e 's!/pkgdir!!g' {} \;
+
+FROM akorn/luarocks:lua5.4-alpine  AS final
+
+RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+	dumb-init
+
+LABEL org.opencontainers.image.title="Busted"
+LABEL org.opencontainers.image.description="A containerized version of Busted, a unit testing framework for Lua."
+LABEL org.opencontainers.image.authors="Caleb Maclennan <caleb@alerque.com>"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.url="https://github.com/lunarmodules/busted/pkgs/container/busted"
+LABEL org.opencontainers.image.source="https://github.com/lunarmodules/busted"
+
+COPY --from=builder /pkgdir /
+RUN busted --version
+
+WORKDIR /data
+
+ENTRYPOINT ["busted", "--verbose"]

--- a/README.md
+++ b/README.md
@@ -89,6 +89,79 @@ luarocks make
 busted spec
 ```
 
+Docker
+------
+
+Alternatively Busted can be run as a standalone docker container.
+This approach is somewhat limited because many projects will require extra dependencies which will need to be installed inside the Docker container.
+Luarocks is provided in the container so many dependencies can be added.
+The images are based on Alpine Linux so you can also use `apk add` to install system dependencies if needed.
+The Docker use case is probably most advantageous for pure-Lua projects with no dependencies: i.g. small libraries not large apps.
+
+The usage of docker is fairly simple.
+You can either build your own or download a prebuilt version.
+To build your own, execute the following command from the source directory of this project:
+
+```console
+$ docker build -t ghcr.io/lunarmodules/busted:HEAD .
+```
+
+To use a prebuilt one, download it from the GitHub Container Registry.
+Here we use the one tagged *latest*, but you can substitute *latest* for any tagged release.
+
+```console
+$ docker pull ghcr.io/lunarmodules/busted:latest
+```
+
+Once you have a container you can run it on one file or a source tree (substitute *latest* with *HEAD* if you built your own or with the tagged version you want if applicable):
+
+```console
+# Run on an entire project
+$ docker run -v "$(pwd):/data" ghcr.io/lunarmodules/busted:latest
+
+# Run on one directory:
+$ docker run -v "$(pwd):/data" ghcr.io/lunarmodules/busted:latest specs
+```
+
+A less verbose way to run it in most shells is with at alias:
+
+```console
+# In a shell or in your shell's RC file:
+$ alias busted='docker run -v "$(pwd):/data" ghcr.io/lunarmodules/busted:latest'
+
+# Thereafter just run:
+$ busted
+```
+### Use as a CI job
+
+There are actually many ways to run Busted remotely as part of a CI work flow.
+Because packages are available for many platforms, one way would be to just use your platforms native package installation system to pull them into whatever CI runner environment you already use.
+Another way is to pull in the prebuilt Docker container and run that.
+
+As a case study, here is how a workflow could be setup in GitHub Actions:
+
+```yaml
+name: Busted
+on: [push, pull_request]
+jobs:
+  sile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Run Busted
+        uses: lunarmodules/busted@v0
+```
+
+By default the GH Action is configured to run `busted --verbose`, but you can also pass it your own `args` to replace the default input of `.`.
+
+```yaml
+      - name: Run Busted
+        uses: lunarmodules/busted@v0
+        with:
+            args: --tags=MYTAGS
+```
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 busted
 ======
 
-[![Luacheck Lint Status](https://img.shields.io/github/workflow/status/Olivine-Labs/busted/Luacheck?label=Luacheck&logo=Lua)](https://github.com/Olivine-Labs/busted/actions?workflow=Luacheck)
-[![Busted Test Status](https://img.shields.io/github/workflow/status/Olivine-Labs/busted/Busted?label=Linux%20Build&logo=Github)](https://github.com/Olivine-Labs/busted/actions?workflow=Busted)
-[![Join the chat at https://gitter.im/Olivine-Labs/busted](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Olivine-Labs/busted?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Luacheck Lint Status](https://img.shields.io/github/workflow/status/lunarmodules/busted/Luacheck?label=Luacheck&logo=Lua)](https://github.com/lunarmodules/busted/actions?workflow=Luacheck)
+[![Busted Test Status](https://img.shields.io/github/workflow/status/lunarmodules/busted/Busted?label=Linux%20Build&logo=Github)](https://github.com/lunarmodules/busted/actions?workflow=Busted)
+[![Join the chat at https://gitter.im/lunarmodules/busted](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/lunarmodules/busted?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 
 
 busted is a unit testing framework with a focus on being **easy to
 use**. Supports Lua >= 5.1, luajit >= 2.0.0, and moonscript.
 
-Check out the [official docs](http://olivinelabs.com/busted) for
+Check out the [official docs](https://lunarmodules.github.io/busted/) for
 extended info.
 
 busted test specs read naturally without being too verbose. You can even
@@ -62,7 +62,7 @@ end)
 Contributing
 ------------
 
-See [CONTRIBUTING.md](https://github.com/Olivine-Labs/busted/blob/master/CONTRIBUTING.md).
+See [CONTRIBUTING.md](https://github.com/lunarmodules/busted/blob/master/CONTRIBUTING.md).
 All issues, suggestions, and most importantly pull requests are welcome.
 
 Testing
@@ -93,4 +93,4 @@ License
 -------
 
 Copyright 2012-2020 Olivine Labs, LLC.
-MIT licensed. See [LICENSE for details](https://github.com/Olivine-Labs/busted/blob/master/LICENSE).
+MIT licensed. See [LICENSE for details](https://github.com/lunarmodules/busted/blob/master/LICENSE).

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,17 @@
+name: Busted
+description: Busted
+inputs:
+  args:
+    description: Arguments passed to busted
+    required: false
+    default: "."
+runs:
+  using: docker
+  image: docker://ghcr.io/lunarmodules/busted:v2.0.0
+  entrypoint: sh
+  args:
+    - -c
+    - busted ${{ inputs.args }}
+branding:
+  icon: check
+  color: yellow

--- a/busted-scm-2.rockspec
+++ b/busted-scm-2.rockspec
@@ -1,11 +1,19 @@
-package = 'busted'
-version = 'scm-2'
+local package_name = "busted"
+local package_version = "scm"
+local rockspec_revision = "2"
+local github_account_name = "lunarmodules"
+local github_repo_name = package_name
+local git_checkout = package_version == "scm" and "master" or package_version
+
+rockspec_format = "3.0"
+package = package_name
+version = package_version .. "-" .. rockspec_revision
 source = {
-  url = "git://github.com/Olivine-Labs/busted",
-  branch = "master"
+  url = "git+https://github.com/"..github_account_name.."/"..github_repo_name..".git",
+  branch = git_checkout
 }
 description = {
-  summary = 'Elegant Lua unit testing.',
+  summary = 'Elegant Lua unit testing',
   detailed = [[
     An elegant, extensible, testing framework.
     Ships with a large amount of useful asserts,
@@ -14,7 +22,7 @@ description = {
     or TAP for CI integration. Great for TDD
     and unit, integration, and functional tests.
   ]],
-  homepage = 'http://olivinelabs.com/busted/',
+  homepage = "https://lunarmodules.github.io/busted/",
   license = 'MIT <http://opensource.org/licenses/MIT>'
 }
 dependencies = {
@@ -28,6 +36,14 @@ dependencies = {
   'lua-term >= 0.1',
   'penlight >= 1.3.2',
   'mediator_lua >= 1.1.1',
+}
+
+test_dependencies = {
+  "busted",
+}
+
+test = {
+  type = "busted",
 }
 
 build = {


### PR DESCRIPTION
~~This is a false start, see comments in #689. A containerized Docker image is probably not the way to handle this because it needs to *execute* not just inspect the code it is testing. Probably an action that installs stuff in the host container is better.~~

A simple containerized GH Action release, per documentation best used for projects with no additional dependencies but adaptable to other uses as well.
