### PR TITLE
Update official documentation link in the README so it doesn't lead to a 404 page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ busted
 busted is a unit testing framework with a focus on being **easy to
 use**. Supports Lua >= 5.1, luajit >= 2.0.0, and moonscript.
 
-Check out the [official docs](http://olivinelabs.com/busted) for
+Check out the [official docs](https://lunarmodules.github.io/busted/) for
 extended info.
 
 busted test specs read naturally without being too verbose. You can even


### PR DESCRIPTION
Change does what it says on the tin. I was about to file an issue to clarify if this was the proper link when I saw a previous issue about it had already been closed and seemed to indicate this was the right one.

Rather than ask about it again I thought I'd just make a PR so future people don't get confused.