### PR TITLE
chore(deps): Drop references to obsolete external dependency

### DIFF
--- a/.github/workflows/busted.yml
+++ b/.github/workflows/busted.yml
@@ -38,12 +38,8 @@ jobs:
 
       - name: Setup dependencies
         run: |
-          sudo apt-get install libev-dev
           luarocks install penlight ${{ matrix.penlightVersion }}
-          luarocks install luasec
           luarocks install moonscript
-          luarocks install copas
-          luarocks install lua-ev
           luarocks install luacov
           luarocks install --deps-only busted-scm-1.rockspec
 

--- a/.luacov
+++ b/.luacov
@@ -42,7 +42,6 @@ return {
     'term.colors$',
     'term.cursor$',
     'term.init$',
-    'copas$',
     'coxpcall$',
     'mediator$',
     'moonscript.*$',

--- a/README.md
+++ b/README.md
@@ -70,18 +70,13 @@ All issues, suggestions, and most importantly pull requests are welcome.
 Testing
 -------
 
-You'll need `libev` to run async tests. Then do the following, assuming you
-have luarocks installed:
+Assuming you have luarocks installed:
 
 Install these dependencies for core testing:
 
 ```
-luarocks install copas
-luarocks install lua-ev scm --server=http://luarocks.org/repositories/rocks-scm/
 luarocks install moonscript
 ```
-
-(Note: you must have `libev` installed to run `lua-ev`; you can `brew install libev` or `apt-get install libev-dev`)
 
 Then to reinstall and run tests:
 

--- a/spec/.hidden/.luacov
+++ b/spec/.hidden/.luacov
@@ -42,7 +42,6 @@ return {
     'term.colors$',
     'term.cursor$',
     'term.init$',
-    'copas$',
     'coxpcall$',
     'mediator$',
     'moonscript.*$',


### PR DESCRIPTION
Closes #694.

If legit. I have some doubts. The status of async support isn't perfectly clear. We still have a spec file testing various aspects of it. I assume that's why I added the copas installation in 790a9f3 some time after it was removed in e8d51ac.
