### PR TITLE
fix(luajit): ensure that ffi loaded libs will not get GC'ed

### DIFF
--- a/busted/luajit.lua
+++ b/busted/luajit.lua
@@ -60,4 +60,5 @@ return function()
     patch_without_return_value("cdef")
     patch_with_return_value("typeof")
     patch_with_return_value("metatype")
+    patch_with_return_value("load")
   end


### PR DESCRIPTION
This caused an issue when busted would clear `_G` and the lib was unloaded whilst userdata's were still floating around with references to the now unloaded lib. This caused segfaults.