### PR TITLE
chore(readme): fix the introductory example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ describe('Busted unit testing framework', function()
 
     it('should have mocks and spies for functional tests', function()
       local thing = require('thing_module')
-      spy.spy_on(thing, 'greet')
+      spy.on(thing, 'greet')
       thing.greet('Hi!')
 
       assert.spy(thing.greet).was.called()


### PR DESCRIPTION
There is no such table as "spy_on" inside "spy".

![image](https://user-images.githubusercontent.com/41503714/230558783-b6db64dc-3371-45e2-888d-238a28d72819.png)
