### PR TITLE
fix(testing): set LUA_PATH in try script

### DIFF
--- a/try
+++ b/try
@@ -1,4 +1,4 @@
 #!/bin/sh
 luarocks remove busted --force
 luarocks make
-busted $@
+LUA_PATH="./?.lua;./?/init.lua;./src/?/?.lua;./src/?/init.lua;$LUA_PATH" busted $@


### PR DESCRIPTION
This change makes the `try` script work in environments that don't already have `LUA_PATH` set up the way `busted` needs.  The `try` script should eventually be replaced by a `Makefile` that also verifies external dependencies, but this will help for now.