### PR TITLE
change(gtest): update outputter to use standard tracing info

### DIFF
--- a/busted/outputHandlers/gtest.lua
+++ b/busted/outputHandlers/gtest.lua
@@ -125,7 +125,7 @@ return function(options)
   local getFileLine = function(element)
     local fileline = ''
     if element.trace or element.trace.short_src then
-      fileline = colors.cyan(element.trace.short_src) .. ' @ ' ..
+      fileline = colors.cyan(element.trace.short_src) .. ':' ..
                  colors.cyan(element.trace.currentline) .. ': '
     end
     return fileline


### PR DESCRIPTION
instead of `file @ line-no` it now uses `file:line-no` which is standard recognized by more IDE's (eg. output is clickable and takes the user to the source line).

Since the trace info is not part of gtest (busted specific addition), it does not break compatibility. [Examples](https://duckduckgo.com/?t=ffab&q=gtest+output+examples&iax=images&ia=images).