### PR TITLE
fix(json-output): convert error object to string before encoding

### DIFF
--- a/busted/core.lua
+++ b/busted/core.lua
@@ -79,7 +79,7 @@ return function()
     end
 
     info.traceback = debug.traceback('', level)
-    info.message = msg
+    info.message = tostring(msg)
 
     local file = busted.getFile(element)
     return file and file.getTrace(file.name, info) or trimTrace(info)

--- a/busted/outputHandlers/json.lua
+++ b/busted/outputHandlers/json.lua
@@ -14,9 +14,7 @@ return function(options)
       errors = handler.errors,
       duration = handler.getDuration()
     }
-    local ok, result = pcall(function()
-      return json.encode(error_info)
-    end)
+    local ok, result = pcall(json.encode, error_info)
 
     if ok then
       io_write(result)

--- a/busted/outputHandlers/json.lua
+++ b/busted/outputHandlers/json.lua
@@ -7,13 +7,23 @@ return function(options)
   local handler = require 'busted.outputHandlers.base'()
 
   handler.suiteEnd = function()
-    io_write(json.encode({
+    local error_info = {
       pendings = handler.pendings,
       successes = handler.successes,
       failures = handler.failures,
       errors = handler.errors,
       duration = handler.getDuration()
-    }))
+    }
+    local ok, result = pcall(function()
+      return json.encode(error_info)
+    end)
+
+    if ok then
+      io_write(result)
+    else
+      io_write("Failed to encode test results to json: " .. result)
+    end
+
     io_write("\n")
     io_flush()
 


### PR DESCRIPTION
Fixes issue #729

Also worth noting that a better way to handle json encode errors would probably be to report this via the json object instead of just outputting the error directly, but at least this way there is some output indicating the problem (previously no output about error would occur)