### PR TITLE
fix(TAP-output): error if no test files

### DIFF
--- a/busted/outputHandlers/TAP.lua
+++ b/busted/outputHandlers/TAP.lua
@@ -41,7 +41,9 @@ return function(options)
     end
 
     print(string_format(failure, counter, t.name))
-    print('# ' .. t.element.trace.short_src .. ' @ ' .. t.element.trace.currentline)
+    if t.element.trace.short_src then
+      print('# ' .. t.element.trace.short_src .. ' @ ' .. t.element.trace.currentline)
+    end
     if t.randomseed then
       print('# Random seed: ' .. t.randomseed)
     end


### PR DESCRIPTION
This pr will fix the following error that if no test files:

```
busted --output=TAP
not ok 1 - 
/home/linuxbrew/.linuxbrew/opt/lua/bin/lua5.4: ...w/.linuxbrew/share/lua/5.4/busted/outputHandlers/TAP.lua:44: attempt to concatenate a nil value (field 'currentline')
stack traceback:
        ...w/.linuxbrew/share/lua/5.4/busted/outputHandlers/TAP.lua:44: in upvalue 'showFailure'
        ...w/.linuxbrew/share/lua/5.4/busted/outputHandlers/TAP.lua:87: in field 'fn'
        /home/linuxbrew/.linuxbrew/share/lua/5.4/mediator.lua:103: in function </home/linuxbrew/.linuxbrew/share/lua/5.4/mediator.lua:96>
        (...tail calls...)
        ...uxbrew/share/lua/5.4/busted/modules/test_file_loader.lua:46: in upvalue 'getTestFiles'
        ...uxbrew/share/lua/5.4/busted/modules/test_file_loader.lua:57: in upvalue 'getAllTestFiles'
        ...uxbrew/share/lua/5.4/busted/modules/test_file_loader.lua:72: in local 'testFileLoader'
        /home/linuxbrew/.linuxbrew/share/lua/5.4/busted/runner.lua:173: in function 'busted.runner'
        ...linuxbrew/lib/luarocks/rocks-5.4/busted/scm-1/bin/busted:3: in main chunk
        [C]: in ?
```

📝 after fix

This behavior is the same with others output handlers.

```
busted --output=TAP
not ok 1 - 
# Failure message: Cannot find file or directory: spec
not ok 2 - 
# Failure message: No test files found matching Lua pattern: _spec
1..2
```
