### PR TITLE
Hack around cliargs to provide "help" flag

### DIFF
--- a/busted/modules/cli.lua
+++ b/busted/modules/cli.lua
@@ -168,6 +168,10 @@ return function(options)
     -- Parse the cli arguments
     local cliArgs, cliErr = cli:parse(args)
     if not cliArgs then
+      if cliErr:match("^Usage") then
+        return { help = true, helpText = cliErr }, nil
+      end
+
       return nil, appName .. ': error: ' .. cliErr .. '; re-run with --help for usage.'
     end
 

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -41,6 +41,11 @@ return function(options)
     exit(1, forceExit)
   end
 
+  if cliArgs.help then
+    io.stdout:write(cliArgs.helpText)
+    exit(0, forceExit)
+  end
+
   if cliArgs.version then
     -- Return early if asked for the version
     print(busted.version)

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -42,13 +42,13 @@ return function(options)
   end
 
   if cliArgs.help then
-    io.stdout:write(cliArgs.helpText)
+    io.stdout:write(cliArgs.helpText .. '\n')
     exit(0, forceExit)
   end
 
   if cliArgs.version then
     -- Return early if asked for the version
-    print(busted.version)
+    io.stdout:write(busted.version .. '\n')
     exit(0, forceExit)
   end
 

--- a/spec/cl_spec.lua
+++ b/spec/cl_spec.lua
@@ -219,7 +219,7 @@ describe('Tests the busted command-line options', function()
 
   it('tests running with --help specified', function()
     local success, _ = executeBusted('--help')
-    assert.is_false(success)
+    assert.is_true(success)
   end)
 
   it('tests running a non-compiling testfile', function()
@@ -353,7 +353,7 @@ describe('Test busted running standalone', function()
 
   it('tests running with --help specified', function()
     local success = executeLua('spec/cl_standalone.lua --help')
-    assert.is_false(success)
+    assert.is_true(success)
   end)
 
   it('tests running via stdin', function()


### PR DESCRIPTION
Fixes #697

This change adds a check on the error returned from the `cliargs` library, and provides a "help" argument to the consumer code in `busted/runner.lua`.
It is based on the workaround used with the same library here: https://github.com/sile-typesetter/sile/pull/1737/files
except that the code in `busted/runner.lua` probably won't need to change if `cliargs` ever supports adding a `--help` flag in the "correct" way.