### PR TITLE
Unpin cliargs dependency

### DIFF
--- a/busted-scm-1.rockspec
+++ b/busted-scm-1.rockspec
@@ -34,7 +34,7 @@ description = {
 
 dependencies = {
   'lua >= 5.1',
-  'lua_cliargs = 3.0',
+  'lua_cliargs >= 3.0',
   'luasystem >= 0.2.0',
   'dkjson >= 2.1.0',
   'say >= 1.4-1',


### PR DESCRIPTION
I haven't looked into *why* this was pinned in the first place yet, but whatever the reason I think we need to fix it at the source, not this way. This is making it hard to even test the cliargs module, much less release it.
