### PR TITLE
opt: truncated package name in junit report

### DIFF
--- a/busted/outputHandlers/junit.lua
+++ b/busted/outputHandlers/junit.lua
@@ -151,14 +151,14 @@ return function(options)
       if package:find("^@") then
         package = string.sub(package, 2)
       end
-      classname = package .. "." .. class_name .. ":" .. element.trace.currentline
+      class_name = package .. "." .. class_name .. ":" .. element.trace.currentline
     else
-      classname = class_name .. ":" .. element.trace.currentline
+      class_name = class_name .. ":" .. element.trace.currentline
     end
 
     testcase_node = xml.new('testcase', {
       -- junit report uses package names and class names to structurally display result.
-      classname = classname,
+      classname = class_name,
       name = test_case_full_name
     })
     top.xml_doc:add_direct_child(testcase_node)

--- a/busted/outputHandlers/junit.lua
+++ b/busted/outputHandlers/junit.lua
@@ -151,7 +151,6 @@ return function(options)
       if package:find("^@") then
         package = string.sub(package, 2)
       end
-      package = string.gsub(package, "/", ".")
       classname = package .. "." .. class_name .. ":" .. element.trace.currentline
     else
       classname = class_name .. ":" .. element.trace.currentline


### PR DESCRIPTION
The junit output handler extracts package name from trace.short_src, which size is limited to 60 in [the source of lua](https://github.com/lua/lua/blob/c1dc08e8e8e22af9902a6341b4a9a9a7811954cc/lua.h#L508).

When my test file located in a deep path, the junit report will be truncated.

![image](https://github.com/lunarmodules/busted/assets/953781/273389df-7922-4c02-894f-c05af1b64702)

In this PR, I use trace.source instead of trace.short_src.