### PR TITLE
fix(outputHandler_json): for pending tests and json encoding

### DIFF
--- a/spec/cl_output_json.lua
+++ b/spec/cl_output_json.lua
@@ -1,0 +1,5 @@
+-- supporting testfile; belongs to 'cl_output_json_spec.lua'
+
+describe("spec with non string attributes", function()
+  non_string_spec('throws an error when encoded into json')
+end)

--- a/spec/cl_output_json_helper.lua
+++ b/spec/cl_output_json_helper.lua
@@ -1,0 +1,19 @@
+return function(busted, helper, options)
+  local non_string_spec = function(element)
+    local parent = busted.context.parent(element)
+    local status = 'custom'
+    if busted.safe_publish('it', { 'test', 'start' }, element, parent) then
+      busted.safe_publish('it', { 'test', 'end' }, element, parent, status)
+    else
+      status = 'error'
+    end
+  end
+
+  busted.register('non_string_spec', non_string_spec, {
+    default_fn = function() end,
+    non_string_attribute_1 = function() end,
+    non_string_attribute_2 = function() end,
+    non_string_attribute_3 = function() end
+  })
+  return true
+end

--- a/spec/cl_output_json_spec.lua
+++ b/spec/cl_output_json_spec.lua
@@ -1,0 +1,35 @@
+local utils = require 'pl.utils'
+local path = require 'pl.path'
+local busted_cmd = path.is_windows and 'lua bin/busted' or 'eval $(luarocks path) && bin/busted'
+
+-- if exitcode >256, then take MSB as exit code
+local modexit = function(exitcode)
+  if exitcode > 255 then
+    return math.floor(exitcode / 256), exitcode - math.floor(exitcode / 256) * 256
+  else
+    return exitcode
+  end
+end
+
+local execute = function(cmd)
+  local success, exitcode, out, err = utils.executeex(cmd)
+  return not not success, modexit(exitcode), out, err
+end
+
+describe('Tests the busted json output', function()
+  it('encodes pending tests', function()
+    local success, exit_code, out, err = execute(busted_cmd .. ' ' .. '--pattern=cl_pending.lua$ --output=busted/outputHandlers/json.lua')
+
+    assert.is_true(success)
+    assert.is.equal(exit_code, 0)
+    assert.is.equal(err, '')
+  end)
+
+  it('notifies with error if results cannot be encoded', function()
+    local success, exit_code, out, err = execute(busted_cmd .. ' --helper=spec/cl_output_json_helper.lua spec/cl_output_json.lua --output=busted/outputHandlers/json.lua')
+
+    assert.is_false(success)
+    assert.is_not.equal(exit_code, 0)
+    assert.is_truthy(err:find("type 'function' is not supported by JSON"))
+  end)
+end)


### PR DESCRIPTION
Fix for #729: pending tests without function argument have an attribute of `default_fn: <function>`, which cannot be encoded into json.
Improved json output formatter to handle pending tests and provide better error reporting if custom non-string attributes cannot be encoded into json.