### PR TITLE
fix(lua5.5): add local variable

### DIFF
--- a/busted/modules/files/moonscript.lua
+++ b/busted/modules/files/moonscript.lua
@@ -58,9 +58,9 @@ local rewrite_traceback = function(fname, trace)
 
   for line in trace:gmatch('[^\r\n]+') do
     j = j + 1
-    line = rewrite_one(line, '%s*(.-):(%d+): ', ':%d:')
-    line = rewrite_one(line, '<(.*):(%d+)>', ':%d>')
-    lines[j] = line
+    local newline = rewrite_one(line, '%s*(.-):(%d+): ', ':%d:')
+    newline = rewrite_one(newline, '<(.*):(%d+)>', ':%d>')
+    lines[j] = newline
   end
 
   return '\n' .. table.concat(lines, trace:match('[\r\n]+')) .. '\n'


### PR DESCRIPTION
Lua 5.5 has the loop-variable defined as a const, and hence modifying now throws an error.

There might be more instances, but since this is a catch-22 with the Penlight dependency (which is tested using Busted again), its a whack-a-mole for starters...