### PR TITLE
fix: handle possibility of empty args

### DIFF
--- a/busted/modules/cli.lua
+++ b/busted/modules/cli.lua
@@ -213,7 +213,7 @@ return function(options)
     -- handles executeable lua files.
     if cliArgs['lua'] and not cliArgs['ignore-lua'] then
       local _, code = execute(
-        cliArgs['lua']..' '..args[0]..' --ignore-lua '..table.concat(args, ' ')
+        cliArgs['lua']..' '..args[0] or ''..' --ignore-lua '..table.concat(args, ' ')
       )
       exit(code)
     end


### PR DESCRIPTION
Problem: When running busted via a wrapper that was installed using LuaRocks or Lux, with `variables.LUA` set to something other than `lua` (e.g. `/path/to/nlua`), the parser fails with:

```
    E5113: Lua chunk: ...95dc6403f6aafe-busted@2.3.0-1/src/busted/modules/cli.lua:216: attempt to concatenate a nil value
    stack traceback:
        ...95dc6403f6aafe-busted@2.3.0-1/src/busted/modules/cli.lua:216: in function 'parse'
```

This PR handles the case that `args` could be an empty table.