### PR TITLE
feat(watch): add --watch mode for continuous testing

### DIFF
--- a/busted-scm-1.rockspec
+++ b/busted-scm-1.rockspec
@@ -79,6 +79,17 @@ build = {
     ['busted.modules.filter_loader']          = 'busted/modules/filter_loader.lua',
     ['busted.modules.cli']                    = 'busted/modules/cli.lua',
 
+    ['busted.modules.watch']                     = 'busted/modules/watch/init.lua',
+    ['busted.modules.watch.debouncer']           = 'busted/modules/watch/debouncer.lua',
+    ['busted.modules.watch.events']              = 'busted/modules/watch/events.lua',
+    ['busted.modules.watch.state']               = 'busted/modules/watch/state.lua',
+    ['busted.modules.watch.watcher']             = 'busted/modules/watch/watcher.lua',
+    ['busted.modules.watch.watchers.lfs']        = 'busted/modules/watch/watchers/lfs.lua',
+    ['busted.modules.watch.watchers.git']        = 'busted/modules/watch/watchers/git.lua',
+    ['busted.modules.watch.watchers.inotify']    = 'busted/modules/watch/watchers/inotify.lua',
+    ['busted.modules.watch.watchers.fsevents']   = 'busted/modules/watch/watchers/fsevents.lua',
+    ['busted.modules.watch.watchers.win32']      = 'busted/modules/watch/watchers/win32.lua',
+
     ['busted.modules.files.lua']              = 'busted/modules/files/lua.lua',
     ['busted.modules.files.moonscript']       = 'busted/modules/files/moonscript.lua',
     ['busted.modules.files.terra']            = 'busted/modules/files/terra.lua',

--- a/busted/core.lua
+++ b/busted/core.lua
@@ -309,6 +309,11 @@ return function()
   function busted.execute(current)
     if not current then current = busted.context.get() end
     for _, v in pairs(busted.context.children(current)) do
+      -- Check for abort request (used by watch mode)
+      if busted.abortRequested then
+        busted.abortRequested = false
+        break
+      end
       local executor = executors[v.descriptor]
       if executor and not busted.skipAll then
         busted.safe(v.descriptor, function() executor(v) end, v)

--- a/busted/modules/cli.lua
+++ b/busted/modules/cli.lua
@@ -164,6 +164,14 @@ return function(options)
   cli:flag('--[no-]suppress-pending', 'suppress `pending` test output', false, processOption)
   cli:flag('--[no-]defer-print', 'defer print to when test suite is complete', false, processOption)
 
+  -- Watch mode options
+  cli:flag('--watch', 'watch for file changes and rerun tests', false, processOption)
+  cli:option('--watch-delay=MS', 'debounce delay in milliseconds', '300', processNumber)
+  cli:option('--watch-ext=EXT', 'additional file extensions to watch (comma-separated)', nil, processList)
+  cli:option('--watch-include=GLOB', 'glob patterns to include (comma-separated)', nil, processList)
+  cli:option('--watch-exclude=GLOB', 'glob patterns to exclude (comma-separated)', nil, processList)
+  cli:flag('--watch-follow-symlinks', 'follow symlinks when watching', false, processOption)
+
   local function parse(args)
     -- Parse the cli arguments
     local cliArgs, cliErr = cli:parse(args)
@@ -247,6 +255,21 @@ return function(options)
     end
 
     cliArgs['repeat'] = tonumber(cliArgs['repeat'])
+
+    -- Validate watch mode options
+    if cliArgs.watch then
+      if cliArgs['repeat'] and cliArgs['repeat'] > 1 then
+        return nil, appName .. ': error: --watch and --repeat are mutually exclusive'
+      end
+      if cliArgs.coverage then
+        return nil, appName .. ': error: --watch and --coverage are mutually exclusive'
+      end
+    end
+
+    -- Fixup watch mode options
+    cliArgs['watch-ext'] = fixupList(cliArgs['watch-ext'] or {})
+    cliArgs['watch-include'] = fixupList(cliArgs['watch-include'] or {})
+    cliArgs['watch-exclude'] = fixupList(cliArgs['watch-exclude'] or {})
 
     return cliArgs
   end

--- a/busted/modules/watch/debouncer.lua
+++ b/busted/modules/watch/debouncer.lua
@@ -1,0 +1,65 @@
+-- Debouncer module for watch mode
+-- Collects file change events and emits them after a delay
+
+local system = require 'system'
+
+local Debouncer = {}
+Debouncer.__index = Debouncer
+
+function Debouncer.new(delay_ms)
+  local self = setmetatable({}, Debouncer)
+  self.delay_ms = delay_ms or 300
+  self.delay_sec = self.delay_ms / 1000
+  self.pending_files = {}
+  self.last_event_time = nil
+  return self
+end
+
+-- Add a file change event to the pending set
+function Debouncer:add(filepath)
+  self.pending_files[filepath] = true
+  self.last_event_time = system.gettime()
+end
+
+-- Check if we have pending files and debounce period has elapsed
+function Debouncer:ready()
+  if not self.last_event_time then
+    return false
+  end
+  local elapsed = system.gettime() - self.last_event_time
+  return elapsed >= self.delay_sec
+end
+
+-- Get the list of changed files and reset
+function Debouncer:flush()
+  local files = {}
+  for filepath, _ in pairs(self.pending_files) do
+    table.insert(files, filepath)
+  end
+  self.pending_files = {}
+  self.last_event_time = nil
+  return files
+end
+
+-- Check if there are any pending changes
+function Debouncer:has_pending()
+  return next(self.pending_files) ~= nil
+end
+
+-- Get time remaining until ready (in seconds)
+function Debouncer:time_remaining()
+  if not self.last_event_time then
+    return nil
+  end
+  local elapsed = system.gettime() - self.last_event_time
+  local remaining = self.delay_sec - elapsed
+  return remaining > 0 and remaining or 0
+end
+
+-- Reset the debouncer
+function Debouncer:reset()
+  self.pending_files = {}
+  self.last_event_time = nil
+end
+
+return Debouncer

--- a/busted/modules/watch/events.lua
+++ b/busted/modules/watch/events.lua
@@ -1,0 +1,128 @@
+-- Events module for watch mode
+-- File change polling with debouncing
+
+local system = require 'system'
+local Debouncer = require 'busted.modules.watch.debouncer'
+
+local Events = {}
+Events.__index = Events
+
+-- Create a new events poller
+-- @param watcher: Watcher module instance
+function Events.new(watcher)
+  local self = setmetatable({}, Events)
+  self.watcher = watcher
+  self.debouncer = nil  -- Created lazily when debounce option is used
+  self.debounce_delay = nil  -- Current debounce delay (nil = no debouncing)
+  return self
+end
+
+-- Poll for events with optional timeout and debouncing
+-- @param opts.timeout: poll timeout in seconds (default 0.1)
+-- @param opts.debounce: debounce delay in ms (nil = no debouncing)
+-- @return array of events, each: {type='file'|'error'|'timeout', ...}
+function Events:poll(opts)
+  opts = opts or {}
+  local timeout = opts.timeout or 0.1
+  local debounce = opts.debounce
+  local events = {}
+
+  -- Configure debouncer if debounce option changed
+  if debounce ~= self.debounce_delay then
+    self.debounce_delay = debounce
+    if debounce and debounce > 0 then
+      self.debouncer = Debouncer.new(debounce)
+    else
+      self.debouncer = nil
+    end
+  end
+
+  -- Sleep for the poll timeout
+  system.sleep(timeout)
+
+  -- Poll for file changes
+  local file_events = self:poll_files()
+  for _, evt in ipairs(file_events) do
+    table.insert(events, evt)
+  end
+
+  -- If no events, return timeout event
+  if #events == 0 then
+    table.insert(events, { type = 'timeout' })
+  end
+
+  return events
+end
+
+-- Poll for file changes and handle debouncing
+-- @return array of file events
+function Events:poll_files()
+  local events = {}
+
+  if not self.watcher then
+    return events
+  end
+
+  -- Poll the watcher for changes
+  local ok, changes = pcall(function()
+    return self.watcher:poll()
+  end)
+
+  if not ok then
+    -- Watcher error
+    table.insert(events, {
+      type = 'error',
+      source = 'watcher',
+      msg = tostring(changes)
+    })
+    return events
+  end
+
+  -- If no debouncer, emit changes immediately
+  if not self.debouncer then
+    if changes then
+      for _, change in ipairs(changes) do
+        table.insert(events, {
+          type = 'file',
+          path = change.path
+        })
+      end
+    end
+    return events
+  end
+
+  -- Add changes to debouncer
+  if changes and #changes > 0 then
+    for _, change in ipairs(changes) do
+      self.debouncer:add(change.path)
+    end
+  end
+
+  -- Check if debouncer is ready to emit
+  if self.debouncer:ready() then
+    local changed_files = self.debouncer:flush()
+    for _, filepath in ipairs(changed_files) do
+      table.insert(events, {
+        type = 'file',
+        path = filepath
+      })
+    end
+  end
+
+  return events
+end
+
+-- Check if there are pending file changes (not yet debounced)
+function Events:has_pending_changes()
+  if not self.debouncer then
+    return false
+  end
+  return self.debouncer:has_pending()
+end
+
+-- Get time until debouncer is ready
+function Events:time_until_ready()
+  return self.debouncer and self.debouncer:time_remaining()
+end
+
+return Events

--- a/busted/modules/watch/init.lua
+++ b/busted/modules/watch/init.lua
@@ -1,0 +1,222 @@
+-- Watch mode orchestrator for Busted
+-- Main entry point for watch mode functionality
+
+local path = require 'pl.path'
+
+local Watcher = require 'busted.modules.watch.watcher'
+local State = require 'busted.modules.watch.state'
+local Events = require 'busted.modules.watch.events'
+
+local WatchMode = {}
+WatchMode.__index = WatchMode
+
+-- ANSI escape codes
+local CLEAR_SCREEN = '\27[2J\27[H'
+
+function WatchMode.new(busted, options)
+  local self = setmetatable({}, WatchMode)
+
+  self.busted = busted
+  self.options = options or {}
+
+  -- Configuration
+  self.delay_ms = tonumber(options['watch-delay']) or 300
+  self.extensions = self:build_extensions(options)
+  self.include_patterns = options['watch-include'] or {}
+  self.exclude_patterns = options['watch-exclude'] or {}
+  self.follow_symlinks = options['watch-follow-symlinks'] or false
+  self.directories = options.ROOT or { '.' }
+
+  -- Components
+  self.state = State.new({ project_paths = self.directories })
+  self.watcher = nil
+  self.events = nil  -- Initialized in start()
+
+  -- State
+  self.running = false
+  self.last_exit_code = 0
+
+  return self
+end
+
+-- Build list of extensions to watch based on options
+function WatchMode:build_extensions(options)
+  local extensions = { '.lua' }
+
+  -- Add extensions from --watch-ext
+  if options['watch-ext'] then
+    for _, ext in ipairs(options['watch-ext']) do
+      if ext:sub(1, 1) ~= '.' then
+        ext = '.' .. ext
+      end
+      table.insert(extensions, ext)
+    end
+  end
+
+  -- Add extensions from loaders
+  local loaders = options.loaders or {}
+  if type(loaders) == 'string' then
+    loaders = { loaders }
+  end
+
+  for _, loader in ipairs(loaders) do
+    if loader == 'moonscript' then
+      table.insert(extensions, '.moon')
+    elseif loader == 'fennel' then
+      table.insert(extensions, '.fnl')
+    elseif loader == 'terra' then
+      table.insert(extensions, '.t')
+    end
+  end
+
+  return extensions
+end
+
+-- Initialize the file watcher
+function WatchMode:init_watcher()
+  local watcher, warnings = Watcher.create({
+    extensions = self.extensions,
+    include_patterns = self.include_patterns,
+    exclude_patterns = self.exclude_patterns,
+    follow_symlinks = self.follow_symlinks,
+    recursive = self.options.recursive ~= false,
+    poll_interval = self.delay_ms,
+  })
+
+  if not watcher then
+    for _, warning in ipairs(warnings) do
+      io.stderr:write('watch: warning: ' .. warning .. '\n')
+    end
+    return nil, 'failed to initialize file watcher'
+  end
+
+  -- Print warnings about fallback
+  for _, warning in ipairs(warnings) do
+    io.stderr:write('watch: ' .. warning .. '\n')
+  end
+
+  self.watcher = watcher
+  return true
+end
+
+-- Set up directories to watch
+function WatchMode:setup_watches()
+  -- Watch the root directories
+  for _, dir in ipairs(self.directories) do
+    if path.isdir(dir) then
+      self.watcher:watch(dir)
+    elseif path.isfile(dir) then
+      -- If a specific file is given, watch its directory
+      self.watcher:watch(path.dirname(dir))
+    end
+  end
+
+  -- Also watch src/ if it exists
+  if path.isdir('src') then
+    self.watcher:watch('src')
+  end
+end
+
+-- Clear the screen
+function WatchMode:clear_screen()
+  io.stdout:write(CLEAR_SCREEN)
+  io.stdout:flush()
+end
+
+-- Run the test suite
+function WatchMode:run_tests(files_filter)
+  -- Clear project modules from cache
+  self.state:clear_all()
+
+  -- Reset abort flag
+  self.busted.abortRequested = false
+
+  -- Run the execute function
+  local execute = require 'busted.execute'(self.busted)
+
+  -- Take a snapshot of loaded modules after test run
+  self.state:snapshot()
+
+  return self.last_exit_code
+end
+
+-- Handle file change events from events module
+function WatchMode:handle_file_event(evt)
+  -- Invalidate changed modules
+  self.state:invalidate({ evt.path })
+  return true  -- Signal that tests should be run
+end
+
+-- Main watch loop
+function WatchMode:start(run_tests_fn)
+  self.running = true
+
+  -- Initialize watcher
+  local ok, err = self:init_watcher()
+  if not ok then
+    io.stderr:write('watch: error: ' .. err .. '\n')
+    return 1
+  end
+
+  -- Set up directories to watch
+  self:setup_watches()
+
+  -- Create unified event poller
+  self.events = Events.new(self.watcher)
+
+  -- Initial test run
+  self:clear_screen()
+  self.last_exit_code = run_tests_fn()
+
+  -- Take initial module snapshot
+  self.state:snapshot()
+
+  -- Print watching message
+  io.stdout:write('\nWatching for file changes... (Ctrl+C to exit)\n')
+  io.stdout:flush()
+
+  -- Main loop using unified event polling
+  while self.running do
+    local evts = self.events:poll({ timeout = 0.1, debounce = self.delay_ms })
+
+    local should_run_tests = false
+
+    for _, evt in ipairs(evts) do
+      if evt.type == 'file' then
+        if self:handle_file_event(evt) then
+          should_run_tests = true
+        end
+      elseif evt.type == 'error' then
+        io.stderr:write('watch: ' .. evt.source .. ': ' .. evt.msg .. '\n')
+      end
+      -- 'timeout' events are ignored
+    end
+
+    -- Run tests if needed
+    if self.running and should_run_tests then
+      -- Signal abort if test is running
+      self.busted.abortRequested = true
+      self:clear_screen()
+      self.last_exit_code = run_tests_fn()
+      io.stdout:write('\nWatching for file changes... (Ctrl+C to exit)\n')
+      io.stdout:flush()
+    end
+  end
+
+  -- Cleanup: stop watcher
+  self.watcher:stop()
+
+  return self.last_exit_code
+end
+
+-- Stop the watch loop
+function WatchMode:stop()
+  self.running = false
+end
+
+-- Set the last exit code
+function WatchMode:set_exit_code(code)
+  self.last_exit_code = code
+end
+
+return WatchMode

--- a/busted/modules/watch/state.lua
+++ b/busted/modules/watch/state.lua
@@ -1,0 +1,124 @@
+-- State module for watch mode
+-- Handles module cache invalidation between test runs
+
+local path = require 'pl.path'
+
+local State = {}
+State.__index = State
+
+function State.new(options)
+  local self = setmetatable({}, State)
+  self.project_paths = options.project_paths or { '.' }
+  self.tracked_modules = {}
+  return self
+end
+
+-- Normalize a path for comparison
+local function normalize_path(filepath)
+  return path.normpath(path.abspath(filepath))
+end
+
+-- Check if a module path is within the project
+function State:is_project_module(module_path)
+  if not module_path then
+    return false
+  end
+
+  local normalized = normalize_path(module_path)
+
+  for _, project_path in ipairs(self.project_paths) do
+    local project_normalized = normalize_path(project_path)
+    if normalized:sub(1, #project_normalized) == project_normalized then
+      return true
+    end
+  end
+
+  return false
+end
+
+-- Track which modules are loaded from the project
+function State:snapshot()
+  self.tracked_modules = {}
+
+  for name, _ in pairs(package.loaded) do
+    local info = self:get_module_info(name)
+    if info and self:is_project_module(info.path) then
+      self.tracked_modules[name] = info.path
+    end
+  end
+
+  return self.tracked_modules
+end
+
+-- Get module info (path) from package.loaded
+function State:get_module_info(name)
+  -- Try to find the source file for a loaded module
+  local searchers = package.searchers or package.loaders
+  if not searchers then
+    return nil
+  end
+
+  for _, searcher in ipairs(searchers) do
+    local result = searcher(name)
+    if type(result) == 'function' then
+      -- Get the path from debug info
+      local info = debug.getinfo(result, 'S')
+      if info and info.source and info.source:sub(1, 1) == '@' then
+        return { path = info.source:sub(2) }
+      end
+    end
+  end
+
+  return nil
+end
+
+-- Invalidate modules that were loaded from changed files
+function State:invalidate(changed_files)
+  local invalidated = {}
+
+  -- Normalize changed file paths
+  local changed_set = {}
+  for _, filepath in ipairs(changed_files) do
+    changed_set[normalize_path(filepath)] = true
+  end
+
+  -- Find all modules to invalidate
+  for name, module_path in pairs(self.tracked_modules) do
+    local normalized = normalize_path(module_path)
+    if changed_set[normalized] then
+      table.insert(invalidated, name)
+    end
+  end
+
+  -- Clear from package.loaded
+  for _, name in ipairs(invalidated) do
+    package.loaded[name] = nil
+    self.tracked_modules[name] = nil
+  end
+
+  return invalidated
+end
+
+-- Clear all project modules from package.loaded
+function State:clear_all()
+  local cleared = {}
+
+  for name, _ in pairs(self.tracked_modules) do
+    package.loaded[name] = nil
+    table.insert(cleared, name)
+  end
+
+  self.tracked_modules = {}
+  return cleared
+end
+
+-- Get list of currently tracked modules
+function State:get_tracked()
+  local modules = {}
+  for name, module_path in pairs(self.tracked_modules) do
+    table.insert(modules, { name = name, path = module_path })
+  end
+  return modules
+end
+
+return State

--- a/busted/modules/watch/watcher.lua
+++ b/busted/modules/watch/watcher.lua
@@ -1,0 +1,102 @@
+-- Watcher abstraction for watch mode
+-- Provides a tiered fallback chain: native → lfs → git
+
+local path = require 'pl.path'
+
+local Watcher = {}
+
+-- Detect the current platform
+local function detect_platform()
+  if path.is_windows then
+    return 'win32'
+  end
+
+  -- Check for macOS
+  local handle = io.popen('uname -s 2>/dev/null', 'r')
+  if handle then
+    local result = handle:read('*a')
+    handle:close()
+    if result and result:match('Darwin') then
+      return 'fsevents'
+    end
+  end
+
+  -- Default to Linux/inotify
+  return 'inotify'
+end
+
+-- Try to load a watcher module
+local function try_load_watcher(name, options)
+  local ok, watcher_module = pcall(require, 'busted.modules.watch.watchers.' .. name)
+  if not ok then
+    return nil, 'module not found: ' .. tostring(watcher_module)
+  end
+
+  -- Try to create the watcher (this may fail if native deps are missing)
+  local success, watcher = pcall(function()
+    return watcher_module.new(options)
+  end)
+
+  if not success then
+    return nil, 'failed to initialize: ' .. tostring(watcher)
+  end
+
+  return watcher, nil
+end
+
+-- Create a watcher with automatic fallback
+function Watcher.create(options)
+  options = options or {}
+  local warnings = {}
+
+  -- Try native watcher first
+  local platform = detect_platform()
+  local watcher, err = try_load_watcher(platform, options)
+
+  if watcher then
+    return watcher, warnings
+  end
+
+  table.insert(warnings, platform .. ' watcher unavailable: ' .. (err or 'unknown error'))
+
+  -- Try lfs polling as first fallback
+  watcher, err = try_load_watcher('lfs', options)
+  if watcher then
+    table.insert(warnings, 'using lfs polling fallback')
+    return watcher, warnings
+  end
+
+  table.insert(warnings, 'lfs watcher unavailable: ' .. (err or 'unknown error'))
+
+  -- Try git polling as last fallback
+  watcher, err = try_load_watcher('git', options)
+  if watcher then
+    table.insert(warnings, 'using git polling fallback')
+    return watcher, warnings
+  end
+
+  -- No watcher available
+  return nil, { 'no file watcher available - git fallback failed: ' .. (err or 'unknown error') }
+end
+
+-- Get list of available watchers (for diagnostics)
+function Watcher.available()
+  local available = {}
+
+  local watchers = { 'inotify', 'fsevents', 'win32', 'lfs', 'git' }
+  for _, name in ipairs(watchers) do
+    local ok = pcall(require, 'busted.modules.watch.watchers.' .. name)
+    if ok then
+      table.insert(available, name)
+    end
+  end
+
+  return available
+end
+
+-- Get the recommended watcher for this platform
+function Watcher.recommended()
+  return detect_platform()
+end
+
+return Watcher

--- a/busted/modules/watch/watchers/fsevents.lua
+++ b/busted/modules/watch/watchers/fsevents.lua
@@ -1,0 +1,173 @@
+-- macOS FSEvents watcher
+-- Uses the fsevents binding for native file watching on macOS
+
+local fsevents = require 'fsevents'  -- luarocks: luafsevents
+local path = require 'pl.path'
+
+local FSEventsWatcher = {}
+FSEventsWatcher.__index = FSEventsWatcher
+
+function FSEventsWatcher.new(options)
+  local self = setmetatable({}, FSEventsWatcher)
+  self.follow_symlinks = options.follow_symlinks or false
+  self.extensions = options.extensions or { '.lua' }
+  self.include_patterns = options.include_patterns or {}
+  self.exclude_patterns = options.exclude_patterns or {}
+  self.recursive = options.recursive ~= false
+  self.directories = {}
+  self.stream = nil
+  self.callback = nil
+  self.running = false
+  return self
+end
+
+-- Check if a file matches the extension filter
+function FSEventsWatcher:matches_extension(filepath)
+  for _, ext in ipairs(self.extensions) do
+    if filepath:sub(-#ext) == ext then
+      return true
+    end
+  end
+  return false
+end
+
+-- Check if a path matches any of the patterns
+local function matches_patterns(filepath, patterns)
+  if not patterns or #patterns == 0 then
+    return false
+  end
+
+  for _, pattern in ipairs(patterns) do
+    local lua_pattern = pattern
+      :gsub('%.', '%%.')
+      :gsub('%*%*', '.__DOUBLE_STAR__.')
+      :gsub('%*', '[^/]*')
+      :gsub('.__DOUBLE_STAR__.', '.*')
+      :gsub('%?', '.')
+
+    if filepath:match(lua_pattern) then
+      return true
+    end
+  end
+
+  return false
+end
+
+-- Check if a file should be watched
+function FSEventsWatcher:should_watch(filepath)
+  if not self:matches_extension(filepath) then
+    return false
+  end
+
+  if matches_patterns(filepath, self.exclude_patterns) then
+    return false
+  end
+
+  if #self.include_patterns > 0 then
+    return matches_patterns(filepath, self.include_patterns)
+  end
+
+  return true
+end
+
+-- Watch a directory
+function FSEventsWatcher:watch(dir)
+  table.insert(self.directories, path.abspath(dir))
+end
+
+-- Watch multiple directories
+function FSEventsWatcher:watch_all(dirs)
+  for _, dir in ipairs(dirs) do
+    self:watch(dir)
+  end
+end
+
+-- Set the callback for file changes
+function FSEventsWatcher:on_change(callback)
+  self.callback = callback
+end
+
+-- Determine event type from FSEvents flags
+local function event_type(flags)
+  if flags.itemCreated then
+    return 'created'
+  elseif flags.itemRemoved then
+    return 'deleted'
+  elseif flags.itemRenamed then
+    return 'renamed'
+  else
+    return 'modified'
+  end
+end
+
+-- FSEvents callback handler
+local function create_event_handler(watcher)
+  return function(events)
+    local changed = {}
+
+    for _, event in ipairs(events) do
+      local filepath = event.path
+
+      -- Skip directories unless they were created/deleted
+      if not event.flags.itemIsDir or event.flags.itemCreated or event.flags.itemRemoved then
+        if watcher:should_watch(filepath) then
+          table.insert(changed, {
+            path = filepath,
+            event = event_type(event.flags)
+          })
+        end
+      end
+    end
+
+    if #changed > 0 and watcher.callback then
+      watcher.callback(changed)
+    end
+  end
+end
+
+-- Start watching (blocking loop)
+function FSEventsWatcher:start()
+  if #self.directories == 0 then
+    return
+  end
+
+  self.running = true
+
+  -- Create FSEvents stream
+  self.stream = fsevents.create(self.directories, {
+    latency = 0.3,  -- 300ms debounce built into FSEvents
+    noDefer = true,
+    fileEvents = true,  -- Get file-level events (requires macOS 10.7+)
+  }, create_event_handler(self))
+
+  -- Start the event loop
+  self.stream:start()
+
+  -- Run the event loop
+  while self.running do
+    -- FSEvents runs on its own thread, we just need to wait
+    local ok, socket = pcall(require, 'socket')
+    if ok and socket.sleep then
+      socket.sleep(0.1)
+    else
+      local start = os.clock()
+      while os.clock() - start < 0.1 do end
+    end
+  end
+end
+
+-- Stop watching
+function FSEventsWatcher:stop()
+  self.running = false
+  if self.stream then
+    self.stream:stop()
+    self.stream = nil
+  end
+end
+
+-- Get watcher type
+function FSEventsWatcher:type()
+  return 'fsevents'
+end
+
+return FSEventsWatcher

--- a/busted/modules/watch/watchers/git.lua
+++ b/busted/modules/watch/watchers/git.lua
@@ -1,0 +1,222 @@
+-- Git status polling watcher
+-- Uses git status --porcelain as a fallback when lfs is unavailable
+
+local path = require 'pl.path'
+
+local GitWatcher = {}
+GitWatcher.__index = GitWatcher
+
+function GitWatcher.new(options)
+  local self = setmetatable({}, GitWatcher)
+  self.poll_interval = (options.poll_interval or 1000) / 1000  -- Convert ms to seconds
+  self.directories = {}
+  self.extensions = options.extensions or { '.lua' }
+  self.include_patterns = options.include_patterns or {}
+  self.exclude_patterns = options.exclude_patterns or {}
+  self.last_status = {}
+  self.callback = nil
+  self.running = false
+  return self
+end
+
+-- Check if a file matches the extension filter
+function GitWatcher:matches_extension(filepath)
+  for _, ext in ipairs(self.extensions) do
+    if filepath:sub(-#ext) == ext then
+      return true
+    end
+  end
+  return false
+end
+
+-- Check if a path matches any of the patterns
+local function matches_patterns(filepath, patterns)
+  if not patterns or #patterns == 0 then
+    return false
+  end
+
+  for _, pattern in ipairs(patterns) do
+    -- Simple glob-to-pattern conversion
+    local lua_pattern = pattern
+      :gsub('%.', '%%.')
+      :gsub('%*%*', '.__DOUBLE_STAR__.')
+      :gsub('%*', '[^/]*')
+      :gsub('.__DOUBLE_STAR__.', '.*')
+      :gsub('%?', '.')
+
+    if filepath:match(lua_pattern) then
+      return true
+    end
+  end
+
+  return false
+end
+
+-- Check if a file should be watched
+function GitWatcher:should_watch(filepath)
+  -- Check extension
+  if not self:matches_extension(filepath) then
+    return false
+  end
+
+  -- Check exclude patterns
+  if matches_patterns(filepath, self.exclude_patterns) then
+    return false
+  end
+
+  -- Check include patterns (if specified, file must match)
+  if #self.include_patterns > 0 then
+    return matches_patterns(filepath, self.include_patterns)
+  end
+
+  return true
+end
+
+-- Execute a command and capture output
+local function execute_command(cmd)
+  local handle = io.popen(cmd .. ' 2>/dev/null', 'r')
+  if not handle then
+    return nil
+  end
+  local result = handle:read('*a')
+  handle:close()
+  return result
+end
+
+-- Check if we're in a git repository
+function GitWatcher:is_git_repo()
+  local result = execute_command('git rev-parse --is-inside-work-tree')
+  return result and result:match('true')
+end
+
+-- Get git status for tracked and untracked files
+function GitWatcher:get_git_status()
+  local status = {}
+
+  -- Get modified and untracked files
+  local result = execute_command('git status --porcelain')
+  if not result then
+    return status
+  end
+
+  for line in result:gmatch('[^\n]+') do
+    -- Parse git status output: XY filename
+    local state = line:sub(1, 2)
+    local filepath = line:sub(4)
+
+    -- Handle renamed files (R -> source -> dest)
+    if filepath:match(' %-> ') then
+      filepath = filepath:match(' %-> (.+)$')
+    end
+
+    if self:should_watch(filepath) then
+      status[filepath] = state
+    end
+  end
+
+  return status
+end
+
+-- Get list of all tracked files with their hashes
+function GitWatcher:get_tracked_files()
+  local files = {}
+
+  local result = execute_command('git ls-files -s')
+  if not result then
+    return files
+  end
+
+  for line in result:gmatch('[^\n]+') do
+    -- Parse: mode hash stage\tfilepath
+    local hash, filepath = line:match('^%d+ (%x+) %d+\t(.+)$')
+    if hash and filepath and self:should_watch(filepath) then
+      files[filepath] = hash
+    end
+  end
+
+  return files
+end
+
+-- Add a directory to watch
+function GitWatcher:watch(dir)
+  table.insert(self.directories, dir)
+end
+
+-- Add multiple directories
+function GitWatcher:watch_all(dirs)
+  for _, dir in ipairs(dirs) do
+    self:watch(dir)
+  end
+end
+
+-- Check for changes (single poll)
+function GitWatcher:poll()
+  local changed = {}
+  local current_status = self:get_git_status()
+
+  -- Check for new or changed files
+  for filepath, state in pairs(current_status) do
+    local old_state = self.last_status[filepath]
+    if not old_state or old_state ~= state then
+      local event = 'modified'
+      if state:match('^%?') then
+        event = 'created'
+      elseif state:match('^D') or state:match('^.D') then
+        event = 'deleted'
+      end
+      table.insert(changed, { path = filepath, event = event })
+    end
+  end
+
+  -- Check for files that are no longer in status (reverted)
+  for filepath, _ in pairs(self.last_status) do
+    if not current_status[filepath] then
+      table.insert(changed, { path = filepath, event = 'reverted' })
+    end
+  end
+
+  self.last_status = current_status
+  return changed
+end
+
+-- Set the callback for file changes
+function GitWatcher:on_change(callback)
+  self.callback = callback
+end
+
+-- Start watching (blocking loop)
+function GitWatcher:start()
+  -- Initial status capture
+  self.last_status = self:get_git_status()
+  self.running = true
+
+  while self.running do
+    local changed = self:poll()
+
+    if #changed > 0 and self.callback then
+      self.callback(changed)
+    end
+
+    -- Sleep for poll interval
+    local ok, socket = pcall(require, 'socket')
+    if ok and socket.sleep then
+      socket.sleep(self.poll_interval)
+    else
+      -- Fallback: busy wait (not ideal)
+      local start = os.clock()
+      while os.clock() - start < self.poll_interval do end
+    end
+  end
+end
+
+-- Stop watching
+function GitWatcher:stop()
+  self.running = false
+end
+
+-- Get watcher type
+function GitWatcher:type()
+  return 'git'
+end
+
+return GitWatcher

--- a/busted/modules/watch/watchers/inotify.lua
+++ b/busted/modules/watch/watchers/inotify.lua
@@ -1,0 +1,197 @@
+-- Linux inotify watcher
+-- Uses the inotify binding for native file watching on Linux
+
+local inotify = require 'inotify'  -- luarocks: luainotify
+local path = require 'pl.path'
+
+local InotifyWatcher = {}
+InotifyWatcher.__index = InotifyWatcher
+
+-- inotify event flags
+local IN_MODIFY = inotify.IN_MODIFY
+local IN_CREATE = inotify.IN_CREATE
+local IN_DELETE = inotify.IN_DELETE
+local IN_MOVED_TO = inotify.IN_MOVED_TO
+local IN_MOVED_FROM = inotify.IN_MOVED_FROM
+local IN_CLOSE_WRITE = inotify.IN_CLOSE_WRITE
+
+function InotifyWatcher.new(options)
+  local self = setmetatable({}, InotifyWatcher)
+  self.follow_symlinks = options.follow_symlinks or false
+  self.extensions = options.extensions or { '.lua' }
+  self.include_patterns = options.include_patterns or {}
+  self.exclude_patterns = options.exclude_patterns or {}
+  self.recursive = options.recursive ~= false
+  self.handle = inotify.init()
+  self.watches = {}  -- wd -> directory path
+  self.callback = nil
+  self.running = false
+  return self
+end
+
+-- Check if a file matches the extension filter
+function InotifyWatcher:matches_extension(filepath)
+  for _, ext in ipairs(self.extensions) do
+    if filepath:sub(-#ext) == ext then
+      return true
+    end
+  end
+  return false
+end
+
+-- Check if a path matches any of the patterns
+local function matches_patterns(filepath, patterns)
+  if not patterns or #patterns == 0 then
+    return false
+  end
+
+  for _, pattern in ipairs(patterns) do
+    local lua_pattern = pattern
+      :gsub('%.', '%%.')
+      :gsub('%*%*', '.__DOUBLE_STAR__.')
+      :gsub('%*', '[^/]*')
+      :gsub('.__DOUBLE_STAR__.', '.*')
+      :gsub('%?', '.')
+
+    if filepath:match(lua_pattern) then
+      return true
+    end
+  end
+
+  return false
+end
+
+-- Check if a file should be watched
+function InotifyWatcher:should_watch(filepath)
+  if not self:matches_extension(filepath) then
+    return false
+  end
+
+  if matches_patterns(filepath, self.exclude_patterns) then
+    return false
+  end
+
+  if #self.include_patterns > 0 then
+    return matches_patterns(filepath, self.include_patterns)
+  end
+
+  return true
+end
+
+-- Add a watch on a directory
+function InotifyWatcher:add_watch(dir)
+  local flags = IN_MODIFY + IN_CREATE + IN_DELETE + IN_MOVED_TO + IN_MOVED_FROM + IN_CLOSE_WRITE
+  local wd = self.handle:addwatch(dir, flags)
+  if wd then
+    self.watches[wd] = dir
+  end
+  return wd
+end
+
+-- Recursively add watches for all subdirectories
+local function scan_directories(dir, callback)
+  local ok, lfs = pcall(require, 'lfs')
+  if not ok then
+    return
+  end
+
+  callback(dir)
+
+  for entry in lfs.dir(dir) do
+    if entry ~= '.' and entry ~= '..' then
+      local full_path = path.join(dir, entry)
+      local attr = lfs.attributes(full_path)
+      if attr and attr.mode == 'directory' then
+        scan_directories(full_path, callback)
+      end
+    end
+  end
+end
+
+-- Watch a directory
+function InotifyWatcher:watch(dir)
+  if self.recursive then
+    scan_directories(dir, function(d)
+      self:add_watch(d)
+    end)
+  else
+    self:add_watch(dir)
+  end
+end
+
+-- Watch multiple directories
+function InotifyWatcher:watch_all(dirs)
+  for _, dir in ipairs(dirs) do
+    self:watch(dir)
+  end
+end
+
+-- Set the callback for file changes
+function InotifyWatcher:on_change(callback)
+  self.callback = callback
+end
+
+-- Convert inotify event to our event format
+local function event_type(mask)
+  if mask:match('CREATE') or mask:match('MOVED_TO') then
+    return 'created'
+  elseif mask:match('DELETE') or mask:match('MOVED_FROM') then
+    return 'deleted'
+  else
+    return 'modified'
+  end
+end
+
+-- Start watching (blocking loop)
+function InotifyWatcher:start()
+  self.running = true
+
+  while self.running do
+    local events = self.handle:read()
+    if events then
+      local changed = {}
+
+      for _, event in ipairs(events) do
+        local dir = self.watches[event.wd]
+        if dir and event.name then
+          local filepath = path.join(dir, event.name)
+
+          -- Handle new directory creation
+          if event.mask:match('ISDIR') and event.mask:match('CREATE') then
+            if self.recursive then
+              self:add_watch(filepath)
+            end
+          end
+
+          if self:should_watch(filepath) then
+            table.insert(changed, {
+              path = filepath,
+              event = event_type(event.mask)
+            })
+          end
+        end
+      end
+
+      if #changed > 0 and self.callback then
+        self.callback(changed)
+      end
+    end
+  end
+end
+
+-- Stop watching
+function InotifyWatcher:stop()
+  self.running = false
+  -- Close all watches
+  for wd, _ in pairs(self.watches) do
+    self.handle:rmwatch(wd)
+  end
+  self.handle:close()
+end
+
+-- Get watcher type
+function InotifyWatcher:type()
+  return 'inotify'
+end
+
+return InotifyWatcher

--- a/busted/modules/watch/watchers/lfs.lua
+++ b/busted/modules/watch/watchers/lfs.lua
@@ -1,0 +1,211 @@
+-- LuaFileSystem polling watcher
+-- Uses mtime polling as a fallback when native watchers are unavailable
+
+local lfs = require 'lfs'
+local path = require 'pl.path'
+
+local LfsWatcher = {}
+LfsWatcher.__index = LfsWatcher
+
+function LfsWatcher.new(options)
+  local self = setmetatable({}, LfsWatcher)
+  self.poll_interval = (options.poll_interval or 500) / 1000  -- Convert ms to seconds
+  self.follow_symlinks = options.follow_symlinks or false
+  self.watched_files = {}  -- filepath -> { mtime, ... }
+  self.directories = {}
+  self.extensions = options.extensions or { '.lua' }
+  self.include_patterns = options.include_patterns or {}
+  self.exclude_patterns = options.exclude_patterns or {}
+  self.recursive = options.recursive ~= false
+  self.callback = nil
+  self.running = false
+  return self
+end
+
+-- Check if a file matches the extension filter
+function LfsWatcher:matches_extension(filepath)
+  for _, ext in ipairs(self.extensions) do
+    if filepath:sub(-#ext) == ext then
+      return true
+    end
+  end
+  return false
+end
+
+-- Check if a path matches any of the patterns
+local function matches_patterns(filepath, patterns)
+  if not patterns or #patterns == 0 then
+    return false
+  end
+
+  for _, pattern in ipairs(patterns) do
+    -- Simple glob-to-pattern conversion
+    local lua_pattern = pattern
+      :gsub('%.', '%%.')
+      :gsub('%*%*', '.__DOUBLE_STAR__.')
+      :gsub('%*', '[^/]*')
+      :gsub('.__DOUBLE_STAR__.', '.*')
+      :gsub('%?', '.')
+
+    if filepath:match(lua_pattern) then
+      return true
+    end
+  end
+
+  return false
+end
+
+-- Check if a file should be watched
+function LfsWatcher:should_watch(filepath)
+  -- Check extension
+  if not self:matches_extension(filepath) then
+    return false
+  end
+
+  -- Check exclude patterns
+  if matches_patterns(filepath, self.exclude_patterns) then
+    return false
+  end
+
+  -- Check include patterns (if specified, file must match)
+  if #self.include_patterns > 0 then
+    return matches_patterns(filepath, self.include_patterns)
+  end
+
+  return true
+end
+
+-- Get file modification time
+local function get_mtime(filepath, follow_symlinks)
+  local attr
+  if follow_symlinks then
+    attr = lfs.attributes(filepath)
+  else
+    attr = lfs.symlinkattributes(filepath)
+  end
+  return attr and attr.modification
+end
+
+-- Scan a directory and collect files to watch
+function LfsWatcher:scan_directory(dir)
+  local files = {}
+
+  local function scan(current_dir)
+    local ok, iter, dir_obj = pcall(lfs.dir, current_dir)
+    if not ok then
+      return
+    end
+
+    for entry in iter, dir_obj do
+      if entry ~= '.' and entry ~= '..' then
+        local full_path = path.join(current_dir, entry)
+        local attr = lfs.attributes(full_path)
+
+        if attr then
+          if attr.mode == 'file' then
+            if self:should_watch(full_path) then
+              files[full_path] = get_mtime(full_path, self.follow_symlinks)
+            end
+          elseif attr.mode == 'directory' and self.recursive then
+            scan(full_path)
+          end
+        end
+      end
+    end
+  end
+
+  scan(dir)
+  return files
+end
+
+-- Add a directory to watch
+function LfsWatcher:watch(dir)
+  table.insert(self.directories, dir)
+
+  -- Initial scan
+  local files = self:scan_directory(dir)
+  for filepath, mtime in pairs(files) do
+    self.watched_files[filepath] = mtime
+  end
+end
+
+-- Add multiple directories
+function LfsWatcher:watch_all(dirs)
+  for _, dir in ipairs(dirs) do
+    self:watch(dir)
+  end
+end
+
+-- Check for changes (single poll)
+function LfsWatcher:poll()
+  local changed = {}
+
+  -- Check existing files for changes
+  for filepath, old_mtime in pairs(self.watched_files) do
+    local new_mtime = get_mtime(filepath, self.follow_symlinks)
+
+    if not new_mtime then
+      -- File was deleted
+      table.insert(changed, { path = filepath, event = 'deleted' })
+      self.watched_files[filepath] = nil
+    elseif new_mtime ~= old_mtime then
+      -- File was modified
+      table.insert(changed, { path = filepath, event = 'modified' })
+      self.watched_files[filepath] = new_mtime
+    end
+  end
+
+  -- Scan for new files
+  for _, dir in ipairs(self.directories) do
+    local files = self:scan_directory(dir)
+    for filepath, mtime in pairs(files) do
+      if not self.watched_files[filepath] then
+        -- New file
+        table.insert(changed, { path = filepath, event = 'created' })
+        self.watched_files[filepath] = mtime
+      end
+    end
+  end
+
+  return changed
+end
+
+-- Set the callback for file changes
+function LfsWatcher:on_change(callback)
+  self.callback = callback
+end
+
+-- Start watching (blocking loop)
+function LfsWatcher:start()
+  self.running = true
+
+  while self.running do
+    local changed = self:poll()
+
+    if #changed > 0 and self.callback then
+      self.callback(changed)
+    end
+
+    -- Sleep for poll interval
+    local ok, socket = pcall(require, 'socket')
+    if ok and socket.sleep then
+      socket.sleep(self.poll_interval)
+    else
+      -- Fallback: busy wait (not ideal)
+      local start = os.clock()
+      while os.clock() - start < self.poll_interval do end
+    end
+  end
+end
+
+-- Stop watching
+function LfsWatcher:stop()
+  self.running = false
+end
+
+-- Get watcher type
+function LfsWatcher:type()
+  return 'lfs'
+end
+
+return LfsWatcher

--- a/busted/modules/watch/watchers/win32.lua
+++ b/busted/modules/watch/watchers/win32.lua
@@ -1,0 +1,200 @@
+-- Windows ReadDirectoryChangesW watcher
+-- Uses the winapi binding for native file watching on Windows
+
+local winapi = require 'winapi'  -- luarocks: luawinapi
+local path = require 'pl.path'
+
+local Win32Watcher = {}
+Win32Watcher.__index = Win32Watcher
+
+-- Change notification flags
+local FILE_NOTIFY_CHANGE_FILE_NAME = 0x00000001
+local FILE_NOTIFY_CHANGE_DIR_NAME = 0x00000002
+local FILE_NOTIFY_CHANGE_LAST_WRITE = 0x00000010
+
+-- Action types
+local FILE_ACTION_ADDED = 1
+local FILE_ACTION_REMOVED = 2
+local FILE_ACTION_MODIFIED = 3
+local FILE_ACTION_RENAMED_OLD_NAME = 4
+local FILE_ACTION_RENAMED_NEW_NAME = 5
+
+function Win32Watcher.new(options)
+  local self = setmetatable({}, Win32Watcher)
+  self.follow_symlinks = options.follow_symlinks or false
+  self.extensions = options.extensions or { '.lua' }
+  self.include_patterns = options.include_patterns or {}
+  self.exclude_patterns = options.exclude_patterns or {}
+  self.recursive = options.recursive ~= false
+  self.directories = {}
+  self.handles = {}
+  self.callback = nil
+  self.running = false
+  return self
+end
+
+-- Check if a file matches the extension filter
+function Win32Watcher:matches_extension(filepath)
+  for _, ext in ipairs(self.extensions) do
+    if filepath:sub(-#ext) == ext then
+      return true
+    end
+  end
+  return false
+end
+
+-- Check if a path matches any of the patterns
+local function matches_patterns(filepath, patterns)
+  if not patterns or #patterns == 0 then
+    return false
+  end
+
+  for _, pattern in ipairs(patterns) do
+    local lua_pattern = pattern
+      :gsub('%.', '%%.')
+      :gsub('%*%*', '.__DOUBLE_STAR__.')
+      :gsub('%*', '[^/\\]*')
+      :gsub('.__DOUBLE_STAR__.', '.*')
+      :gsub('%?', '.')
+
+    if filepath:match(lua_pattern) then
+      return true
+    end
+  end
+
+  return false
+end
+
+-- Check if a file should be watched
+function Win32Watcher:should_watch(filepath)
+  if not self:matches_extension(filepath) then
+    return false
+  end
+
+  if matches_patterns(filepath, self.exclude_patterns) then
+    return false
+  end
+
+  if #self.include_patterns > 0 then
+    return matches_patterns(filepath, self.include_patterns)
+  end
+
+  return true
+end
+
+-- Create a directory watch handle
+function Win32Watcher:create_watch(dir)
+  local flags = FILE_NOTIFY_CHANGE_FILE_NAME + FILE_NOTIFY_CHANGE_DIR_NAME + FILE_NOTIFY_CHANGE_LAST_WRITE
+
+  local handle = winapi.CreateFile(
+    dir,
+    winapi.FILE_LIST_DIRECTORY,
+    winapi.FILE_SHARE_READ + winapi.FILE_SHARE_WRITE + winapi.FILE_SHARE_DELETE,
+    nil,
+    winapi.OPEN_EXISTING,
+    winapi.FILE_FLAG_BACKUP_SEMANTICS + winapi.FILE_FLAG_OVERLAPPED,
+    nil
+  )
+
+  if handle and handle ~= winapi.INVALID_HANDLE_VALUE then
+    return { handle = handle, dir = dir, flags = flags }
+  end
+
+  return nil
+end
+
+-- Watch a directory
+function Win32Watcher:watch(dir)
+  local watch = self:create_watch(path.abspath(dir))
+  if watch then
+    table.insert(self.directories, dir)
+    table.insert(self.handles, watch)
+  end
+end
+
+-- Watch multiple directories
+function Win32Watcher:watch_all(dirs)
+  for _, dir in ipairs(dirs) do
+    self:watch(dir)
+  end
+end
+
+-- Set the callback for file changes
+function Win32Watcher:on_change(callback)
+  self.callback = callback
+end
+
+-- Convert action to event type
+local function event_type(action)
+  if action == FILE_ACTION_ADDED or action == FILE_ACTION_RENAMED_NEW_NAME then
+    return 'created'
+  elseif action == FILE_ACTION_REMOVED or action == FILE_ACTION_RENAMED_OLD_NAME then
+    return 'deleted'
+  else
+    return 'modified'
+  end
+end
+
+-- Start watching (blocking loop)
+function Win32Watcher:start()
+  if #self.handles == 0 then
+    return
+  end
+
+  self.running = true
+
+  while self.running do
+    for _, watch in ipairs(self.handles) do
+      -- Read directory changes
+      local changes = winapi.ReadDirectoryChangesW(
+        watch.handle,
+        self.recursive,
+        watch.flags
+      )
+
+      if changes and #changes > 0 then
+        local changed = {}
+
+        for _, change in ipairs(changes) do
+          local filepath = path.join(watch.dir, change.filename)
+
+          if self:should_watch(filepath) then
+            table.insert(changed, {
+              path = filepath,
+              event = event_type(change.action)
+            })
+          end
+        end
+
+        if #changed > 0 and self.callback then
+          self.callback(changed)
+        end
+      end
+    end
+
+    -- Small sleep to prevent busy loop
+    local ok, socket = pcall(require, 'socket')
+    if ok and socket.sleep then
+      socket.sleep(0.05)
+    else
+      local start = os.clock()
+      while os.clock() - start < 0.05 do end
+    end
+  end
+end
+
+-- Stop watching
+function Win32Watcher:stop()
+  self.running = false
+  for _, watch in ipairs(self.handles) do
+    winapi.CloseHandle(watch.handle)
+  end
+  self.handles = {}
+end
+
+-- Get watcher type
+function Win32Watcher:type()
+  return 'win32'
+end
+
+return Win32Watcher

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -195,33 +195,113 @@ return function(options)
     suppressPending = cliArgs['suppress-pending'],
   })
 
-  if cliArgs.ROOT then
-    -- Load test directories/files
-    local rootFiles = cliArgs.ROOT
+  -- Function to load test files
+  local function loadTestFiles(rootFilesOverride)
+    local rootFiles = rootFilesOverride or cliArgs.ROOT
     local patterns = cliArgs.pattern
-    local testFileLoader = require 'busted.modules.test_file_loader'(busted, cliArgs.loaders)
-    testFileLoader(rootFiles, patterns, {
-      excludes = cliArgs['exclude-pattern'],
-      verbose = cliArgs.verbose,
-      recursive = cliArgs['recursive'],
-    })
-  else
-    -- Running standalone, use standalone loader
-    local testFileLoader = require 'busted.modules.standalone_loader'(busted)
-    testFileLoader(info, { verbose = cliArgs.verbose })
+
+    if rootFiles then
+      local testFileLoader = require 'busted.modules.test_file_loader'(busted, cliArgs.loaders)
+      testFileLoader(rootFiles, patterns, {
+        excludes = cliArgs['exclude-pattern'],
+        verbose = cliArgs.verbose,
+        recursive = cliArgs['recursive'],
+      })
+    else
+      -- Running standalone, use standalone loader
+      local testFileLoader = require 'busted.modules.standalone_loader'(busted)
+      testFileLoader(info, { verbose = cliArgs.verbose })
+    end
+
+    return true
   end
 
-  local runs = cliArgs['repeat']
-  local execute = require 'busted.execute'(busted)
-  execute(runs, {
-    seed = cliArgs.seed,
-    shuffle = cliArgs['shuffle-files'],
-    sort = cliArgs['sort-files'],
-  })
+  -- Function to run tests once
+  -- Note: resetCounters=true resets failures/errors counters (used by watch mode)
+  local function runTests(resetCounters)
+    if resetCounters then
+      failures = 0
+      errors = 0
+      busted.skipAll = false
+    end
 
-  busted.publish({ 'exit' })
+    local runs = cliArgs['repeat']
+    local executeModule = require 'busted.execute'(busted)
+    executeModule(runs, {
+      seed = cliArgs.seed,
+      shuffle = cliArgs['shuffle-files'],
+      sort = cliArgs['sort-files'],
+    })
 
-  if options.standalone or failures > 0 or errors > 0 then
-    exit(failures + errors, forceExit)
+    return failures + errors
+  end
+
+  -- Reset counters before initial loading
+  -- (errors may be recorded during file loading if no files match)
+  failures = 0
+  errors = 0
+  busted.skipAll = false
+
+  -- Initial test file loading
+  local loadOk, loadExitCode = loadTestFiles()
+  if not loadOk then
+    if not cliArgs.watch then
+      exit(loadExitCode or 0, forceExit)
+    end
+  end
+
+  -- Check if watch mode is enabled
+  if cliArgs.watch then
+    local WatchMode = require 'busted.modules.watch'
+    local watchMode = WatchMode.new(busted, cliArgs)
+
+    -- Function to reload and run tests in watch mode
+    local function watchRunTests(filesOverride)
+      -- Reset counters for each watch run
+      failures = 0
+      errors = 0
+      busted.skipAll = false
+
+      -- Preserve the old context env (contains busted API: describe, it, etc.)
+      local oldctx = busted.context.get()
+
+      -- Clear context for fresh run
+      busted.context.clear()
+      local ctx = busted.context.get()
+
+      -- Restore env and other properties from old context
+      for k, v in pairs(oldctx) do
+        ctx[k] = v
+      end
+
+      -- Reload test files
+      local ok, loadErr = pcall(function()
+        loadTestFiles(filesOverride)
+      end)
+
+      if not ok then
+        io.stderr:write('Error loading tests: ' .. tostring(loadErr) .. '\n')
+        return 1
+      end
+
+      -- Run tests (don't reset counters as we already did above)
+      local exitCode = runTests(false)
+      watchMode:set_exit_code(exitCode)
+      return exitCode
+    end
+
+    -- Start watch mode
+    local exitCode = watchMode:start(watchRunTests)
+    busted.publish({ 'exit' })
+    exit(exitCode, forceExit)
+  else
+    -- Normal execution (non-watch mode)
+    -- Don't reset counters as we already did before loadTestFiles()
+    runTests(false)
+    busted.publish({ 'exit' })
+
+    if options.standalone or failures > 0 or errors > 0 then
+      exit(failures + errors, forceExit)
+    end
   end
 end

--- a/spec/modules/watch/debouncer_spec.lua
+++ b/spec/modules/watch/debouncer_spec.lua
@@ -1,0 +1,108 @@
+local Debouncer = require 'busted.modules.watch.debouncer'
+
+describe('Debouncer', function()
+  local debouncer
+
+  before_each(function()
+    debouncer = Debouncer.new(100)  -- 100ms delay
+  end)
+
+  describe('new', function()
+    it('creates a debouncer with default delay', function()
+      local d = Debouncer.new()
+      assert.equals(300, d.delay_ms)
+      assert.equals(0.3, d.delay_sec)
+    end)
+
+    it('creates a debouncer with custom delay', function()
+      local d = Debouncer.new(500)
+      assert.equals(500, d.delay_ms)
+      assert.equals(0.5, d.delay_sec)
+    end)
+  end)
+
+  describe('add', function()
+    it('adds a file to pending set', function()
+      debouncer:add('/path/to/file.lua')
+      assert.is_true(debouncer:has_pending())
+    end)
+
+    it('deduplicates files', function()
+      debouncer:add('/path/to/file.lua')
+      debouncer:add('/path/to/file.lua')
+      local files = debouncer:flush()
+      assert.equals(1, #files)
+    end)
+
+    it('tracks multiple files', function()
+      debouncer:add('/path/to/file1.lua')
+      debouncer:add('/path/to/file2.lua')
+      local files = debouncer:flush()
+      assert.equals(2, #files)
+    end)
+  end)
+
+  describe('has_pending', function()
+    it('returns false when no files pending', function()
+      assert.is_false(debouncer:has_pending())
+    end)
+
+    it('returns true when files are pending', function()
+      debouncer:add('/path/to/file.lua')
+      assert.is_true(debouncer:has_pending())
+    end)
+  end)
+
+  describe('ready', function()
+    it('returns false when no events', function()
+      assert.is_false(debouncer:ready())
+    end)
+
+    it('returns false immediately after adding', function()
+      debouncer:add('/path/to/file.lua')
+      assert.is_false(debouncer:ready())
+    end)
+  end)
+
+  describe('flush', function()
+    it('returns empty list when no pending files', function()
+      local files = debouncer:flush()
+      assert.equals(0, #files)
+    end)
+
+    it('returns list of pending files', function()
+      debouncer:add('/path/to/file1.lua')
+      debouncer:add('/path/to/file2.lua')
+      local files = debouncer:flush()
+      assert.equals(2, #files)
+    end)
+
+    it('clears pending files after flush', function()
+      debouncer:add('/path/to/file.lua')
+      debouncer:flush()
+      assert.is_false(debouncer:has_pending())
+    end)
+  end)
+
+  describe('reset', function()
+    it('clears all pending files', function()
+      debouncer:add('/path/to/file.lua')
+      debouncer:reset()
+      assert.is_false(debouncer:has_pending())
+    end)
+  end)
+
+  describe('time_remaining', function()
+    it('returns nil when no events', function()
+      assert.is_nil(debouncer:time_remaining())
+    end)
+
+    it('returns remaining time after adding', function()
+      debouncer:add('/path/to/file.lua')
+      local remaining = debouncer:time_remaining()
+      assert.is_not_nil(remaining)
+      assert.is_true(remaining >= 0)
+      assert.is_true(remaining <= 0.1)  -- Should be close to delay_sec
+    end)
+  end)
+end)

--- a/spec/modules/watch/events_integration_spec.lua
+++ b/spec/modules/watch/events_integration_spec.lua
@@ -1,0 +1,181 @@
+-- Integration tests for Events module with real file watcher
+-- These tests create actual files and verify file change detection works
+
+local lfs = require 'lfs'
+local path = require 'pl.path'
+local file = require 'pl.file'
+local dir = require 'pl.dir'
+local Events = require 'busted.modules.watch.events'
+local LfsWatcher = require 'busted.modules.watch.watchers.lfs'
+
+describe('Events integration', function()
+  local temp_dir
+  local test_file
+
+  -- Create temp directory before each test
+  before_each(function()
+    -- Use os.tmpname() for portable temp file name, then make it a directory
+    local tmpname = os.tmpname()
+    -- On some systems, os.tmpname creates the file, so remove it first
+    os.remove(tmpname)
+    temp_dir = tmpname .. '_events_test'
+    lfs.mkdir(temp_dir)
+    test_file = path.join(temp_dir, 'test.lua')
+    file.write(test_file, '-- initial content')
+  end)
+
+  -- Clean up temp directory after each test
+  after_each(function()
+    if temp_dir and path.exists(temp_dir) then
+      dir.rmtree(temp_dir)
+    end
+  end)
+
+  describe('with real LFS watcher', function()
+    it('detects file modifications', function()
+      -- Create watcher watching the temp directory
+      local watcher = LfsWatcher.new({
+        extensions = { '.lua' },
+        recursive = true,
+        poll_interval = 10  -- Fast polling for tests
+      })
+      watcher:watch(temp_dir)
+
+      -- Create events with the real watcher
+      local events = Events.new(watcher)
+
+      -- First poll should show no changes (initial state captured)
+      local evts = events:poll({ timeout = 0.001 })
+      assert.equal(1, #evts)
+      assert.equal('timeout', evts[1].type)
+
+      -- Wait for file system mtime to change (some systems have 1s resolution)
+      local system = require 'system'
+      system.sleep(1.1)
+
+      -- Modify the file
+      file.write(test_file, '-- modified content ' .. os.time())
+
+      -- Poll again - should detect the change
+      evts = events:poll({ timeout = 0.001 })
+      local file_event_found = false
+      for _, evt in ipairs(evts) do
+        if evt.type == 'file' and evt.path:match('test%.lua$') then
+          file_event_found = true
+          assert.is_nil(evt.change)  -- No 'change' field in new API
+        end
+      end
+      assert.is_true(file_event_found, 'Expected to detect file modification')
+    end)
+
+    it('detects new file creation', function()
+      -- Create watcher watching the temp directory
+      local watcher = LfsWatcher.new({
+        extensions = { '.lua' },
+        recursive = true,
+        poll_interval = 10
+      })
+      watcher:watch(temp_dir)
+
+      -- Create events with the real watcher
+      local events = Events.new(watcher)
+
+      -- Initial poll
+      events:poll({ timeout = 0.001 })
+
+      -- Create a new file
+      local new_file = path.join(temp_dir, 'new_test.lua')
+      file.write(new_file, '-- new file')
+
+      -- Poll - should detect the new file
+      local evts = events:poll({ timeout = 0.001 })
+      local new_file_found = false
+      for _, evt in ipairs(evts) do
+        if evt.type == 'file' and evt.path:match('new_test%.lua$') then
+          new_file_found = true
+        end
+      end
+      assert.is_true(new_file_found, 'Expected to detect new file creation')
+    end)
+
+    it('respects debounce option', function()
+      -- Create watcher
+      local watcher = LfsWatcher.new({
+        extensions = { '.lua' },
+        recursive = true,
+        poll_interval = 10
+      })
+      watcher:watch(temp_dir)
+
+      local events = Events.new(watcher)
+
+      -- Initial poll
+      events:poll({ timeout = 0.001, debounce = 100 })
+
+      -- Wait for mtime resolution and modify file
+      local system = require 'system'
+      system.sleep(1.1)  -- Wait for mtime resolution
+      file.write(test_file, '-- modified again ' .. os.time())
+
+      -- Poll immediately with debounce - should not emit yet (change goes to debouncer)
+      local evts = events:poll({ timeout = 0.001, debounce = 100 })
+      local immediate_file_found = false
+      for _, evt in ipairs(evts) do
+        if evt.type == 'file' then
+          immediate_file_found = true
+        end
+      end
+      assert.is_false(immediate_file_found, 'Should not emit immediately with debounce')
+      assert.is_true(events:has_pending_changes())
+
+      -- Wait for debounce period
+      system.sleep(0.15)  -- 150ms > 100ms debounce
+
+      -- Poll again - should emit now
+      evts = events:poll({ timeout = 0.001, debounce = 100 })
+      local debounced_file_found = false
+      for _, evt in ipairs(evts) do
+        if evt.type == 'file' and evt.path:match('test%.lua$') then
+          debounced_file_found = true
+        end
+      end
+      assert.is_true(debounced_file_found, 'Expected to emit after debounce period')
+    end)
+
+    it('filters by extension', function()
+      -- Create watcher that only watches .lua files
+      local watcher = LfsWatcher.new({
+        extensions = { '.lua' },
+        recursive = true,
+        poll_interval = 10
+      })
+      watcher:watch(temp_dir)
+
+      local events = Events.new(watcher)
+
+      -- Initial poll
+      events:poll({ timeout = 0.001 })
+
+      -- Create a .txt file (should be ignored)
+      local txt_file = path.join(temp_dir, 'test.txt')
+      file.write(txt_file, 'text content')
+
+      -- Create a .lua file (should be detected)
+      local lua_file = path.join(temp_dir, 'test2.lua')
+      file.write(lua_file, '-- lua content')
+
+      -- Poll
+      local evts = events:poll({ timeout = 0.001 })
+      local txt_found = false
+      local lua_found = false
+      for _, evt in ipairs(evts) do
+        if evt.type == 'file' then
+          if evt.path:match('%.txt$') then txt_found = true end
+          if evt.path:match('test2%.lua$') then lua_found = true end
+        end
+      end
+      assert.is_false(txt_found, 'Should not detect .txt file')
+      assert.is_true(lua_found, 'Should detect .lua file')
+    end)
+  end)
+end)

--- a/spec/modules/watch/events_spec.lua
+++ b/spec/modules/watch/events_spec.lua
@@ -1,0 +1,241 @@
+-- Tests for Events module (watch mode file change polling)
+
+local Events = require 'busted.modules.watch.events'
+
+describe('Events', function()
+  -- Mock watcher module
+  local function create_mock_watcher(opts)
+    opts = opts or {}
+    return {
+      poll = function()
+        if opts.poll_error then
+          error(opts.poll_error)
+        end
+        return opts.changes or {}
+      end,
+    }
+  end
+
+  describe('new', function()
+    it('creates an events instance', function()
+      local watcher = create_mock_watcher()
+
+      local events = Events.new(watcher)
+      assert.is_not_nil(events)
+      assert.equal(watcher, events.watcher)
+      assert.is_nil(events.debouncer)  -- No debouncer by default
+    end)
+  end)
+
+  describe('poll', function()
+    it('returns timeout event when no events', function()
+      local watcher = create_mock_watcher()
+      local events = Events.new(watcher)
+
+      local evts = events:poll({ timeout = 0.001 })
+      assert.equal(1, #evts)
+      assert.equal('timeout', evts[1].type)
+    end)
+
+    it('emits file events immediately without debounce option', function()
+      local watcher = create_mock_watcher({
+        changes = {
+          { path = 'test.lua', event = 'modified' }
+        }
+      })
+      local events = Events.new(watcher)
+
+      -- Without debounce, events are emitted immediately
+      local evts = events:poll({ timeout = 0.001 })
+      assert.equal(1, #evts)
+      assert.equal('file', evts[1].type)
+      assert.equal('test.lua', evts[1].path)
+      assert.is_nil(evts[1].change)  -- No 'change' field
+    end)
+
+    it('adds file changes to debouncer when debounce option set', function()
+      local watcher = create_mock_watcher({
+        changes = {
+          { path = 'test.lua', event = 'modified' }
+        }
+      })
+      local events = Events.new(watcher)
+
+      -- First poll with debounce adds to debouncer but doesn't emit (not ready yet)
+      local evts = events:poll({ timeout = 0.001, debounce = 100 })
+      assert.equal(1, #evts)
+      assert.equal('timeout', evts[1].type)
+      assert.is_true(events:has_pending_changes())
+    end)
+
+    it('emits debounced events after delay', function()
+      local call_count = 0
+      local watcher = {
+        poll = function()
+          call_count = call_count + 1
+          if call_count == 1 then
+            return {{ path = 'test.lua', event = 'modified' }}
+          end
+          return {}
+        end,
+      }
+      local events = Events.new(watcher)
+
+      -- First poll - adds to debouncer
+      events:poll({ timeout = 0.001, debounce = 1 })  -- 1ms debounce
+      assert.is_true(events:has_pending_changes())
+
+      -- Wait for debounce
+      local system = require 'system'
+      system.sleep(0.01)  -- 10ms should be enough
+
+      -- Second poll - should emit
+      local evts = events:poll({ timeout = 0.001, debounce = 1 })
+      local file_found = false
+      for _, evt in ipairs(evts) do
+        if evt.type == 'file' then
+          file_found = true
+          assert.equal('test.lua', evt.path)
+        end
+      end
+      assert.is_true(file_found)
+    end)
+
+    it('returns error event on watcher error', function()
+      local watcher = create_mock_watcher({
+        poll_error = 'watcher failed'
+      })
+      local events = Events.new(watcher)
+
+      local evts = events:poll({ timeout = 0.001 })
+      assert.is_true(#evts >= 1)
+
+      local error_found = false
+      for _, evt in ipairs(evts) do
+        if evt.type == 'error' then
+          error_found = true
+          assert.equal('watcher', evt.source)
+          assert.is_truthy(evt.msg:match('watcher failed'))
+        end
+      end
+      assert.is_true(error_found)
+    end)
+
+    it('handles nil watcher gracefully', function()
+      local events = Events.new(nil)
+
+      local evts = events:poll({ timeout = 0.001 })
+      assert.equal(1, #evts)
+      assert.equal('timeout', evts[1].type)
+    end)
+
+    it('creates debouncer lazily when debounce option provided', function()
+      local watcher = create_mock_watcher()
+      local events = Events.new(watcher)
+
+      assert.is_nil(events.debouncer)
+
+      -- Poll without debounce - no debouncer created
+      events:poll({ timeout = 0.001 })
+      assert.is_nil(events.debouncer)
+
+      -- Poll with debounce - debouncer created
+      events:poll({ timeout = 0.001, debounce = 100 })
+      assert.is_not_nil(events.debouncer)
+    end)
+
+    it('removes debouncer when debounce option removed', function()
+      local watcher = create_mock_watcher()
+      local events = Events.new(watcher)
+
+      -- Poll with debounce
+      events:poll({ timeout = 0.001, debounce = 100 })
+      assert.is_not_nil(events.debouncer)
+
+      -- Poll without debounce - debouncer removed
+      events:poll({ timeout = 0.001 })
+      assert.is_nil(events.debouncer)
+    end)
+  end)
+
+  describe('poll_files', function()
+    it('returns empty array when no changes', function()
+      local watcher = create_mock_watcher()
+      local events = Events.new(watcher)
+
+      local file_events = events:poll_files()
+      assert.same({}, file_events)
+    end)
+
+    it('emits file events immediately without debouncer', function()
+      local watcher = create_mock_watcher({
+        changes = {
+          { path = 'file1.lua', event = 'modified' },
+          { path = 'file2.lua', event = 'created' },
+        }
+      })
+      local events = Events.new(watcher)
+
+      local file_events = events:poll_files()
+      assert.equal(2, #file_events)
+      assert.equal('file', file_events[1].type)
+      assert.equal('file1.lua', file_events[1].path)
+      assert.equal('file', file_events[2].type)
+      assert.equal('file2.lua', file_events[2].path)
+    end)
+  end)
+
+  describe('has_pending_changes', function()
+    it('returns false when no debouncer', function()
+      local watcher = create_mock_watcher()
+      local events = Events.new(watcher)
+
+      assert.is_false(events:has_pending_changes())
+    end)
+
+    it('returns false when debouncer has no pending', function()
+      local watcher = create_mock_watcher()
+      local events = Events.new(watcher)
+
+      -- Create debouncer by polling with debounce option
+      events:poll({ timeout = 0.001, debounce = 100 })
+
+      assert.is_false(events:has_pending_changes())
+    end)
+
+    it('returns true when debouncer has pending', function()
+      local watcher = create_mock_watcher({
+        changes = {{ path = 'test.lua' }}
+      })
+      local events = Events.new(watcher)
+
+      -- Create debouncer and add changes
+      events:poll({ timeout = 0.001, debounce = 100 })
+
+      assert.is_true(events:has_pending_changes())
+    end)
+  end)
+
+  describe('time_until_ready', function()
+    it('returns nil when no debouncer', function()
+      local watcher = create_mock_watcher()
+      local events = Events.new(watcher)
+
+      assert.is_nil(events:time_until_ready())
+    end)
+
+    it('returns time remaining when debouncer has pending', function()
+      local watcher = create_mock_watcher({
+        changes = {{ path = 'test.lua' }}
+      })
+      local events = Events.new(watcher)
+
+      -- Create debouncer and add changes
+      events:poll({ timeout = 0.001, debounce = 1000 })  -- 1 second delay
+
+      local time = events:time_until_ready()
+      assert.is_number(time)
+      assert.is_true(time > 0)
+    end)
+  end)
+end)

--- a/spec/modules/watch/state_spec.lua
+++ b/spec/modules/watch/state_spec.lua
@@ -1,0 +1,95 @@
+local State = require 'busted.modules.watch.state'
+local path = require 'pl.path'
+
+describe('State', function()
+  local state
+  local cwd = path.currentdir()
+
+  before_each(function()
+    state = State.new({ project_paths = { cwd } })
+  end)
+
+  describe('new', function()
+    it('creates a state with default options', function()
+      local s = State.new({})
+      assert.is_table(s.project_paths)
+      assert.is_table(s.tracked_modules)
+    end)
+
+    it('creates a state with custom project paths', function()
+      local s = State.new({ project_paths = { '/custom/path' } })
+      assert.equals('/custom/path', s.project_paths[1])
+    end)
+  end)
+
+  describe('is_project_module', function()
+    it('returns false for nil path', function()
+      assert.is_false(state:is_project_module(nil))
+    end)
+
+    it('returns true for path within project', function()
+      local test_path = path.join(cwd, 'some', 'file.lua')
+      assert.is_true(state:is_project_module(test_path))
+    end)
+
+    it('returns false for path outside project', function()
+      assert.is_false(state:is_project_module('/completely/different/path.lua'))
+    end)
+  end)
+
+  describe('get_tracked', function()
+    it('returns empty list initially', function()
+      local tracked = state:get_tracked()
+      assert.equals(0, #tracked)
+    end)
+  end)
+
+  describe('clear_all', function()
+    it('clears tracked modules', function()
+      -- Manually add some tracked modules for testing
+      state.tracked_modules['test.module'] = '/path/to/test/module.lua'
+      package.loaded['test.module'] = {}
+
+      local cleared = state:clear_all()
+      assert.equals(1, #cleared)
+      assert.equals('test.module', cleared[1])
+      assert.is_nil(package.loaded['test.module'])
+    end)
+
+    it('returns empty list when nothing tracked', function()
+      local cleared = state:clear_all()
+      assert.equals(0, #cleared)
+    end)
+  end)
+
+  describe('invalidate', function()
+    it('removes modules from package.loaded', function()
+      -- Setup a tracked module
+      local test_path = path.join(cwd, 'test_module.lua')
+      state.tracked_modules['test.module'] = test_path
+      package.loaded['test.module'] = {}
+
+      local invalidated = state:invalidate({ test_path })
+      assert.equals(1, #invalidated)
+      assert.is_nil(package.loaded['test.module'])
+    end)
+
+    it('only invalidates matching files', function()
+      local test_path1 = path.join(cwd, 'module1.lua')
+      local test_path2 = path.join(cwd, 'module2.lua')
+
+      state.tracked_modules['module1'] = test_path1
+      state.tracked_modules['module2'] = test_path2
+      package.loaded['module1'] = {}
+      package.loaded['module2'] = {}
+
+      local invalidated = state:invalidate({ test_path1 })
+      assert.equals(1, #invalidated)
+      assert.is_nil(package.loaded['module1'])
+      assert.is_not_nil(package.loaded['module2'])
+
+      -- Cleanup
+      package.loaded['module2'] = nil
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary
Add `--watch` mode for continuous testing during development. When enabled,
busted monitors source files and automatically re-runs tests when changes
are detected.

## Motivation
Fast feedback loops are essential for productive development. Watch mode
eliminates the need to manually re-run tests after each change, making
TDD workflows smoother.

## Features
- **Multi-platform support**: Native file system events on Linux (inotify),
  macOS (FSEvents), and Windows, with LFS polling fallback
- **Debouncing**: Configurable delay to batch rapid changes (--watch-delay)
- **Extension filtering**: Watch .lua by default, add more with --watch-ext
- **Pattern matching**: Include/exclude files with --watch-include/exclude
- **Module cache management**: Automatically clears Lua module cache for
  accurate re-runs

## Usage
```bash
# Basic usage
busted --watch spec/

# With options
busted --watch --watch-delay 500 --watch-ext moon spec/
```

## Test Plan
- [x] Unit tests for debouncer, events, state modules
- [x] Integration tests with real file system changes
- [x] Manual testing on macOS (FSEvents backend)
- [ ] Testing on Linux (inotify backend)
- [ ] Testing on Windows (win32 backend)