### PR TITLE
fix(tests): be more relaxed in testing pathnames

### DIFF
--- a/spec/fixtures_spec.lua
+++ b/spec/fixtures_spec.lua
@@ -6,12 +6,12 @@ describe("fixtures:", function()
 
     it("returns the absolute fixture path", function()
       local path = fixtures.path("fixtures/myfile.txt")
-      assert.match("^.-busted[/\\]spec[/\\]fixtures[/\\]myfile.txt$", path)
+      assert.match("^.-busted[^/\\]*[/\\]spec[/\\]fixtures[/\\]myfile.txt$", path)
     end)
 
     it("returns the absolute fixture path normalized", function()
       local path = fixtures.path("../fixtures/myfile.txt")
-      assert.match("^.-busted[/\\]fixtures[/\\]myfile.txt$", path)
+      assert.match("^.-busted[^/\\]*[/\\]fixtures[/\\]myfile.txt$", path)
     end)
 
     it("errors on bad input", function()
@@ -83,4 +83,3 @@ describe("fixtures:", function()
 
 
 end)
-


### PR DESCRIPTION
The path in my case is in fact versioned, so the test fails with

    Failure -> spec/fixtures_spec.lua @ 7
    fixtures: path() returns the absolute fixture path
    spec/fixtures_spec.lua:9: Expected strings to match.
    Passed in:
    (string) '/home/abuild/rpmbuild/BUILD/lua55-busted-2.3.0-build/busted-2.3.0/spec/fixtures/myfile.txt'
    Expected:
    (string) '^.-busted[/\]spec[/\]fixtures[/\]myfile.txt$'

    stack traceback:
            spec/fixtures_spec.lua:9: in function <spec/fixtures_spec.lua:7>

    Failure -> spec/fixtures_spec.lua @ 12
    fixtures: path() returns the absolute fixture path normalized
    spec/fixtures_spec.lua:14: Expected strings to match.
    Passed in:
    (string) '/home/abuild/rpmbuild/BUILD/lua55-busted-2.3.0-build/busted-2.3.0/fixtures/myfile.txt'
    Expected:
    (string) '^.-busted[/\]fixtures[/\]myfile.txt$'

    stack traceback:
            spec/fixtures_spec.lua:14: in function <spec/fixtures_spec.lua:12>

Fixes: https://github.com/lunarmodules/busted/issues/768