### PR TITLE
Drop lua-term since lua-system has the same functionality

### DIFF
--- a/busted-scm-1.rockspec
+++ b/busted-scm-1.rockspec
@@ -35,11 +35,10 @@ description = {
 dependencies = {
   'lua >= 5.1',
   'lua_cliargs >= 3.0',
-  'luasystem >= 0.2.0',
+  'luasystem >= 0.3.0',
   'dkjson >= 2.1.0',
   'say >= 1.4-1',
   'luassert >= 1.9.0-1',
-  'lua-term >= 0.1',
   'penlight >= 1.15.0',
   'mediator_lua >= 1.1.1',
 }
@@ -90,6 +89,7 @@ build = {
     ['busted.outputHandlers.TAP']             = 'busted/outputHandlers/TAP.lua',
     ['busted.outputHandlers.json']            = 'busted/outputHandlers/json.lua',
     ['busted.outputHandlers.junit']           = 'busted/outputHandlers/junit.lua',
+    ['busted.outputHandlers.colors']          = 'busted/outputHandlers/colors.lua',
     ['busted.outputHandlers.gtest']           = 'busted/outputHandlers/gtest.lua',
     ['busted.outputHandlers.sound']           = 'busted/outputHandlers/sound.lua',
 

--- a/busted/outputHandlers/colors.lua
+++ b/busted/outputHandlers/colors.lua
@@ -1,0 +1,65 @@
+-- fork of the lua-term's colors.lua, check it out: https://github.com/hoelzro/lua-term/blob/master/term/colors.lua
+
+local pairs = pairs
+local tostring = tostring
+local setmetatable = setmetatable
+local schar = string.char
+
+local colors = {}
+
+local colormt = {}
+
+function colormt:__tostring()
+    return self.value
+end
+
+function colormt:__concat(other)
+    return tostring(self) .. tostring(other)
+end
+
+function colormt:__call(s)
+    return self .. s .. colors.reset
+end
+
+local function makecolor(value)
+    return setmetatable({ value = schar(27) .. '[' .. tostring(value) .. 'm' }, colormt)
+end
+
+local colorvalues = {
+    -- attributes
+    reset      = 0,
+    clear      = 0,
+    default    = 0,
+    bright     = 1,
+    dim        = 2,
+    underscore = 4,
+    blink      = 5,
+    reverse    = 7,
+    hidden     = 8,
+
+    -- foreground
+    black   = 30,
+    red     = 31,
+    green   = 32,
+    yellow  = 33,
+    blue    = 34,
+    magenta = 35,
+    cyan    = 36,
+    white   = 37,
+
+    -- background
+    onblack   = 40,
+    onred     = 41,
+    ongreen   = 42,
+    onyellow  = 43,
+    onblue    = 44,
+    onmagenta = 45,
+    oncyan    = 46,
+    onwhite   = 47,
+}
+
+for c, v in pairs(colorvalues) do
+    colors[c] = makecolor(v)
+end
+
+return colors

--- a/busted/outputHandlers/gtest.lua
+++ b/busted/outputHandlers/gtest.lua
@@ -34,7 +34,7 @@ return function(options)
     luassert:set_parameter("TableErrorHighlightColor", "none")
 
   elseif cliArgs.color then
-    colors = require 'term.colors'
+    colors = require 'busted.outputHandlers.colors'
     luassert:set_parameter("TableErrorHighlightColor", "red")
 
   else
@@ -43,7 +43,7 @@ return function(options)
       colors = setmetatable({}, {__index = function() return function(s) return s end end})
       luassert:set_parameter("TableErrorHighlightColor", "none")
     else
-      colors = require 'term.colors'
+      colors = require 'busted.outputHandlers.colors'
       luassert:set_parameter("TableErrorHighlightColor", "red")
     end
   end

--- a/busted/outputHandlers/gtest.lua
+++ b/busted/outputHandlers/gtest.lua
@@ -1,5 +1,5 @@
 local pretty = require 'pl.pretty'
-local term = require 'term'
+local system = require 'system'
 local luassert = require 'luassert'
 local io = io
 local type = type
@@ -9,7 +9,7 @@ local io_write = io.write
 local io_flush = io.flush
 local colors
 
-local isatty = io.type(io.stdout) == 'file' and term.isatty(io.stdout)
+local isatty = io.type(io.stdout) == 'file' and system.isatty(io.stdout)
 
 return function(options)
   local busted = require 'busted'

--- a/busted/outputHandlers/utfTerminal.lua
+++ b/busted/outputHandlers/utfTerminal.lua
@@ -1,6 +1,6 @@
 local s = require 'say'
 local pretty = require 'pl.pretty'
-local term = require 'term'
+local system = require 'system'
 local luassert = require 'luassert'
 local io = io
 local type = type
@@ -11,7 +11,7 @@ local io_flush = io.flush
 local pairs = pairs
 local colors
 
-local isatty = io.type(io.stdout) == 'file' and term.isatty(io.stdout)
+local isatty = io.type(io.stdout) == 'file' and system.isatty(io.stdout)
 
 return function(options)
   local busted = require 'busted'

--- a/busted/outputHandlers/utfTerminal.lua
+++ b/busted/outputHandlers/utfTerminal.lua
@@ -35,7 +35,7 @@ return function(options)
     luassert:set_parameter("TableErrorHighlightColor", "none")
 
   elseif cliArgs.color then
-    colors = require 'term.colors'
+    colors = require 'busted.outputHandlers.colors'
     luassert:set_parameter("TableErrorHighlightColor", "red")
 
   else
@@ -44,7 +44,7 @@ return function(options)
       colors = setmetatable({}, {__index = function() return function(s) return s end end})
       luassert:set_parameter("TableErrorHighlightColor", "none")
     else
-      colors = require 'term.colors'
+      colors = require 'busted.outputHandlers.colors'
       luassert:set_parameter("TableErrorHighlightColor", "red")
     end
   end

--- a/busted/runner.lua
+++ b/busted/runner.lua
@@ -10,9 +10,9 @@ return function(options)
 
   local path = require 'pl.path'
   local tablex = require 'pl.tablex'
-  local term = require 'term'
+  local system = require 'system'
 
-  local isatty = io.type(io.stdout) == 'file' and term.isatty(io.stdout)
+  local isatty = io.type(io.stdout) == 'file' and system.isatty(io.stdout)
   options = tablex.update(require 'busted.options', options or {})
   options.output = options.output or (isatty and 'utfTerminal' or 'plainTerminal')
 


### PR DESCRIPTION
Removed the `lua-term` as described here: https://github.com/lunarmodules/busted/issues/771#issuecomment-4602083767

- Ran `just check`, no new test failures. Seems like the change in the infrastructure layer where are no tests.
- Ran `rg` to search `'test` in the code, no more entries found.
- Cloned `colors.lua` from `lua-term` to `busted/outputHandlers/colors.lua`. Mentioned it in docs. Kept it AS-IS, didn't change a thing. I might remove unused code if you think it'd be better.
- I didn't create a new rockspec, because that it's better be done before the release.

The only thing left to do is: 

```diff
--- rockspecs/busted-2.3.0-1.rockspec	2026-06-02 14:59:47
+++ rockspecs/busted-2.3.1-1.rockspec	2026-06-02 17:59:25
@@ -1,5 +1,5 @@
 local package_name = "busted"
-local package_version = "2.3.0"
+local package_version = "2.3.1"
 local rockspec_revision = "1"
 local github_account_name = "lunarmodules"
 local github_repo_name = package_name
@@ -34,11 +34,10 @@
 dependencies = {
   'lua >= 5.1',
   'lua_cliargs >= 3.0',
-  'luasystem >= 0.2.0',
+  'luasystem >= 0.3.0',
   'dkjson >= 2.1.0',
   'say >= 1.4-1',
   'luassert >= 1.9.0-1',
-  'lua-term >= 0.1',
   'penlight >= 1.15.0',
   'mediator_lua >= 1.1.1',
 }
```

Closes: https://github.com/lunarmodules/busted/issues/771

---

I'm not sure about AI policy, so I write it here: 

- commit messages are made using codex, 
- everything else I did myself. 

I'm eager to make more contributions after this one, so it'd be good to understand the AI-usage policy. I don't want to violate it.
